### PR TITLE
Fix failing timestamps

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -342,7 +342,7 @@ class Controller:
                     f"this time period. The simulation for {start_year}-{end_year} cannot be performed"
                 )
                 return False
-            # self._network.remove_invalid_datetime(invalid_datetime)
+            self._network.remove_invalid_datetime(invalid_datetime)
 
             return True
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -299,7 +299,7 @@ class Controller:
                     ].set_index("Time")["Power (MW)"]
 
                 # Net power : forward - backward.
-                # We create a new series object to enforce its index (all timestamps that needs to be simulated)
+                # We create a new series object to enforce its index (all timestamps that need to be simulated)
                 interco_powers = pd.Series(flow_forward.sub(flow_backward, fill_value=0),
                                            index=self._network.datetime_index).fillna(0)
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -7,7 +7,9 @@ import numpy as np
 import pandas as pd
 
 from src.input_reader import InputReader
+from src.interconnection import OUT_ZONE_NAME
 from src.network import Network
+from src.zone import Zone
 
 SIMULATED_POWERS_DIRECTORY_ROOT = 'countries_simulated_powers_by_sector'
 SIMULATED_POWERS_FILE_ROOT = 'simulated_powers_by_sector'
@@ -127,8 +129,8 @@ class Controller:
                         price_no_power = (row_cons_min[idx + 2] + row_prod_min[idx + 2]) / 2
                         warnings.warn(
                             f"Incoherent no power prices in {zone.name}-{sectors[idx]} : production starts before the "
-                            f"end of consumption ({row_prod_min[idx+2]} vs {row_cons_min[idx+2]}). Mean price is set "
-                            f"for both no power prices.")
+                            f"end of consumption ({row_prod_min[idx + 2]} vs {row_cons_min[idx + 2]}). Mean price is "
+                            "set for both no power prices.")
                         row_cons_min[idx + 2] = price_no_power
                         row_prod_min[idx + 2] = price_no_power
 
@@ -162,7 +164,6 @@ class Controller:
             - cons_none must be less than or equal to prod_none
 
         :param price_models: Dictionary containing the price models per zone and sector
-        :param storages: List of sector names that are storages
 
         :raises ValueError: If any of the logical consistency checks fail
         """
@@ -297,14 +298,32 @@ class Controller:
                     (self._interco_powers['zone_from'] == zone_to) & (self._interco_powers['zone_to'] == zone_from)
                     ].set_index("Time")["Power (MW)"]
 
-                # Net power : forward - backward
-                interco_powers = flow_forward.sub(flow_backward, fill_value=0).sort_index()
+                # Net power : forward - backward.
+                # We create a new series object to enforce its index (all timestamps that needs to be simulated)
+                interco_powers = pd.Series(flow_forward.sub(flow_backward, fill_value=0),
+                                           index=self._network.datetime_index).fillna(0)
 
                 self._network.add_interconnection(self._network.zones[zone_from], self._network.zones[zone_to],
                                                   power_rating, interco_powers)
 
+            # Add interconnection with exterior
+            exterior = Zone(OUT_ZONE_NAME, historical_prices=pd.Series())
+            for zone_name, zone in self._network.zones.items():
+                flow_forward = self._interco_powers[(self._interco_powers['zone_from'] == zone_name) & (
+                            self._interco_powers['zone_to'] == OUT_ZONE_NAME)].set_index("Time")["Power (MW)"]
+
+                flow_backward = self._interco_powers[(self._interco_powers['zone_from'] == OUT_ZONE_NAME) & (
+                        self._interco_powers['zone_to'] == zone_name)].set_index("Time")["Power (MW)"]
+
+                # Net power : forward - backward
+                net_export_to_exterior = pd.Series(flow_forward.sub(flow_backward, fill_value=0),
+                                                   index=self._network.datetime_index).fillna(0)
+
+                self._network.add_exterior_interconnection(zone, exterior, net_export_to_exterior)
+
             # ------- add loads -------
             # Demand = production + net import
+            invalid_datetime = set()
             for zone_name, zone in self._network.zones.items():
                 net_import = pd.Series(0, index=self._network.datetime_index)
                 for interconnection in zone.interconnections:
@@ -312,7 +331,18 @@ class Controller:
                         net_import -= interconnection.historical_powers
                     elif interconnection.zone_to.name == zone_name:
                         net_import += interconnection.historical_powers
-                zone.compute_demand(net_import)
+                negative_demand_datetime = zone.compute_demand(net_import)
+                invalid_datetime.update(negative_demand_datetime)
+
+            # Check the number of time steps to remove
+            missing_steps += len(invalid_datetime)
+            if missing_steps > missing_steps_limit:
+                warnings.warn(
+                    f"More than {missing_steps_limit} timesteps cannot be used due to negative computed demand for "
+                    f"this time period. The simulation for {start_year}-{end_year} cannot be performed"
+                )
+                return False
+            # self._network.remove_invalid_datetime(invalid_datetime)
 
             return True
 
@@ -331,21 +361,14 @@ class Controller:
             if not model_built:
                 continue
             n_runs = 0
-            failed_timesteps = list()
             for timestep in self._network.datetime_index:
-                try:
-                    self._network.run_opf(timestep)
-                    n_runs += 1
-                    if n_runs % 24 == 0:
-                        computation_time = time.time() - t0
-                        mn = int(computation_time // 60)
-                        s = int(computation_time - 60 * mn)
-                        print(f"{n_runs} OPF ({n_runs // 24} days) run in {mn}mn{s}s")
-                except:  # FIXME use specific exception and understand why some timesteps fail
-                    failed_timesteps.append(timestep)
-                    warnings.warn(f"OPF failure for timestep {timestep}")
-            if len(failed_timesteps) > 0:
-                print(f"{len(failed_timesteps)} OPF did not converge:\n{failed_timesteps}")
+                self._network.run_opf(timestep)
+                n_runs += 1
+                if n_runs % 24 == 0:
+                    computation_time = time.time() - t0
+                    mn = int(computation_time // 60)
+                    s = int(computation_time - 60 * mn)
+                    print(f"{n_runs} OPF ({n_runs // 24} days) run in {mn}mn{s}s")
             self.export_opfs()
 
     def export_opfs(self):

--- a/src/input_reader.py
+++ b/src/input_reader.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pandas as pd
 
+from src.interconnection import OUT_ZONE_NAME
+
 PROD_FOLDER_NAME = "countries_power_production_by_sector_2015_2019"
 PRICES_FOLDER_NAME = "annual_spot_prices_by_country_2015_2019"
 INPUT_EXCEL_NAME = "User_inputs.xlsx"
@@ -528,11 +530,13 @@ class InputReader:
 
         # Verify if the sheet exists
         file_path_data = self._db_dir / INTERCO_FOLDER_NAME / INTERCO_POWERS_FILE_NAME
-        xls = pd.ExcelFile(file_path_data)
 
         all_years_data = []
+        sheets_to_read = set()
+        for (year_min, year_max) in self._years:
+            sheets_to_read.update([str(year) for year in range(year_min, year_max + 1)])
 
-        for sheet_name in xls.sheet_names:
+        for sheet_name in sheets_to_read:
             # Load data from the specified sheet
             df_interco_raw = pd.read_excel(file_path_data, sheet_name=sheet_name)
 
@@ -563,6 +567,8 @@ class InputReader:
             # Map countries to zones
             df_interco_renamed["zone_from"] = df_interco_renamed["country_from"].map(country_to_zone)
             df_interco_renamed["zone_to"] = df_interco_renamed["country_to"].map(country_to_zone)
+            df_interco_renamed["zone_from"].fillna(OUT_ZONE_NAME, inplace=True)
+            df_interco_renamed["zone_to"].fillna(OUT_ZONE_NAME, inplace=True)
 
             # Remove intra-zone flows
             df_interco_filtered = df_interco_renamed[df_interco_renamed["zone_from"] != df_interco_renamed["zone_to"]]

--- a/src/interconnection.py
+++ b/src/interconnection.py
@@ -244,8 +244,37 @@ class Interconnection:
                 x, cost = x12, cost12
         return x, cost
 
-    def reset_power(self):
+    def init_current_power(self, timestep: pd.Timestamp):
+        self._current_power = self._historical_powers[timestep]
+
+
+OUT_ZONE_NAME = "OUTSIDE"
+
+
+class ExteriorInterconnection(Interconnection):
+    """
+    This class allows to represent a connection with zones that are not modelled.
+    The net export of this connection is fixed.
+    """
+
+    def __init__(self, zone_from: Zone, zone_to: Zone, historical_power_flows: pd.Series):
+        power_rating = 1e9
+        assert zone_to.name == OUT_ZONE_NAME
+        super().__init__(zone_from, zone_to, power_rating, historical_power_flows)
+
+    def optimise_export(self, timestep: pd.Timestamp) -> float:
         """
-        The export in the line is reset to 0
+        For an :class:`ExteriorInterconnection`, there is nothing to optimise: the export remains the same as the
+        historical one. Thus, set_power is not called and the cost benefit is zero because nothing has changed.
+
+        Parameters
+        ----------
+        timestep: (unused) Timestamp currently simulated.
+
+        Returns
+        -------
+        Zero, as nothing is optimised here.
         """
-        self._current_power = 0
+        return 0
+
+


### PR DESCRIPTION
The previous pull request introduced a simple OPF solver which was failing for several timestamps. 
The following PR results of the investigation of this problem and allows to model adequatly a part of the European market.

In short, the OPF was failing during its initialisation (no export in each line) because the cost function bounds of some nodes did not include 0. This corresponded to a negative demand in the zone.

This is in most cases due to neglecting the import/export with zones that are not included in the study by the user when computing the demand of a zone before the OPF. Therefore, we now consider all exchanges to compute the demand but we also introduce a zone corresponding to the "OUTSIDE". Its interconnection with zones under study has a fixed power value (the historical one). **This does not solve the problem of OPF failure during initialisation but allow to have a clearer model of the European network, without negative demand**.

The true solution to fix the OPF initialisation is to use values that for sure produce an feasible solution, which was not achieved with 0 net export in all lines. These values are simply the historical ones.
Thus, we now initialise the export in the lines with historical data so that the OPF has a first feasible solution and then it tries to optimise the system