### PR TITLE
Energy constraints for storages

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -75,7 +75,7 @@ class Controller:
             for zone in self._zones:
                 self._network.add_zone(zone_name=zone, sectors_historical_powers=powers[zone],
                                        storages=self._storages, controllable_sectors=self._controllable_sectors,
-                                       historical_prices=prices[zone])
+                                       historical_prices=prices[zone], energy_ratings=dict(), mean_inflows=dict())
 
             self._network.build_price_models(self._prices_init[f"{start_year}-{end_year}"])
             self.export_price_models(start_year, end_year, create_file, current_date)
@@ -232,6 +232,9 @@ class Controller:
             zone: df[(df.index.year >= start_year) & (df.index.year <= end_year)]
             for zone, df in self._powers.items()
         }
+        storages_data = self._input_reader.read_db_storages_energy_data()
+        storages_energy_ratings = storages_data["Energy MWh"]
+        storages_mean_inflows = storages_data["Mean inflow MW"]
 
         for zone in self._zones:
             if ('PL' in self._input_reader.get_countries_in_zone(zone)
@@ -243,7 +246,8 @@ class Controller:
             else:
                 self._network.add_zone(zone_name=zone, sectors_historical_powers=powers[zone],
                                        storages=self._storages, controllable_sectors=self._controllable_sectors,
-                                       historical_prices=prices[zone])
+                                       historical_prices=prices[zone], energy_ratings=storages_energy_ratings[zone],
+                                       mean_inflows=storages_mean_inflows[zone])
 
         # We suppose that the production data is complete for all zones (8784 hours/year for leap years, 8760 otherwise)
         missing_steps = len(next(iter(powers.values()))) - len(self._network.datetime_index)

--- a/src/controller.py
+++ b/src/controller.py
@@ -75,7 +75,7 @@ class Controller:
             for zone in self._zones:
                 self._network.add_zone(zone_name=zone, sectors_historical_powers=powers[zone],
                                        storages=self._storages, controllable_sectors=self._controllable_sectors,
-                                       historical_prices=prices[zone], energy_ratings=dict(), mean_inflows=dict())
+                                       historical_prices=prices[zone])
 
             self._network.build_price_models(self._prices_init[f"{start_year}-{end_year}"])
             self.export_price_models(start_year, end_year, create_file, current_date)
@@ -232,9 +232,6 @@ class Controller:
             zone: df[(df.index.year >= start_year) & (df.index.year <= end_year)]
             for zone, df in self._powers.items()
         }
-        storages_data = self._input_reader.read_db_storages_energy_data()
-        storages_energy_ratings = storages_data["Energy MWh"]
-        storages_mean_inflows = storages_data["Mean inflow MW"]
 
         for zone in self._zones:
             if ('PL' in self._input_reader.get_countries_in_zone(zone)
@@ -246,8 +243,7 @@ class Controller:
             else:
                 self._network.add_zone(zone_name=zone, sectors_historical_powers=powers[zone],
                                        storages=self._storages, controllable_sectors=self._controllable_sectors,
-                                       historical_prices=prices[zone], energy_ratings=storages_energy_ratings[zone],
-                                       mean_inflows=storages_mean_inflows[zone])
+                                       historical_prices=prices[zone])
 
         # We suppose that the production data is complete for all zones (8784 hours/year for leap years, 8760 otherwise)
         missing_steps = len(next(iter(powers.values()))) - len(self._network.datetime_index)
@@ -348,6 +344,9 @@ class Controller:
                 return False
             self._network.remove_invalid_datetime(invalid_datetime)
 
+            storages_data = self._input_reader.read_db_storages_energy_data()
+            self._network.build_storage_constraints(energy_ratings=storages_data["Energy MWh"],
+                                                    mean_inflows=storages_data["Mean inflow MW"])
             return True
 
     def run_opfs(self):
@@ -365,15 +364,27 @@ class Controller:
             if not model_built:
                 continue
             n_runs = 0
+            warnings_years = dict()
             for timestep in self._network.datetime_index:
-                self._network.run_opf(timestep)
+                converged, warnings_timestep = self._network.run_opf(timestep)
+                if len(warnings_timestep) > 0:
+                    warnings_years[timestep] = warnings_timestep
                 n_runs += 1
                 if n_runs % 24 == 0:
                     computation_time = time.time() - t0
                     mn = int(computation_time // 60)
                     s = int(computation_time - 60 * mn)
                     print(f"{n_runs} OPF ({n_runs // 24} days) run in {mn}mn{s}s")
+
+            # Save results
             self.export_opfs()
+
+            # Save warnings
+            folder_name = f"{SIMULATED_POWERS_DIRECTORY_ROOT}_{start_year}-{end_year}"
+            file_path = self._work_dir / folder_name / "Warnings.xlsx"
+            warnings_df = pd.DataFrame(warnings_years).transpose()
+            with pd.ExcelWriter(file_path) as writer:
+                warnings_df.to_excel(writer, sheet_name="Warnings", index=True)
 
     def export_opfs(self):
         """
@@ -396,7 +407,12 @@ class Controller:
             for sector in sectors:
                 sector_name = sector.name
                 simulated_powers = sector.simulated_powers
-                sector_data[f'{sector_name}_MW'] = simulated_powers
+                if sector.is_load:
+                    simulated_powers = -simulated_powers
+                if f'{sector_name}_MW' in sector_data.keys():  # storage
+                    sector_data[f'{sector_name}_MW'] += simulated_powers
+                else:
+                    sector_data[f'{sector_name}_MW'] = simulated_powers
 
             # Build the DataFrame with data from all sectors of the current zone
             combined_df = pd.concat(sector_data, axis=1)

--- a/src/controller.py
+++ b/src/controller.py
@@ -364,11 +364,8 @@ class Controller:
             if not model_built:
                 continue
             n_runs = 0
-            warnings_years = dict()
             for timestep in self._network.datetime_index:
-                converged, warnings_timestep = self._network.run_opf(timestep)
-                if len(warnings_timestep) > 0:
-                    warnings_years[timestep] = warnings_timestep
+                self._network.run_opf(timestep)
                 n_runs += 1
                 if n_runs % 24 == 0:
                     computation_time = time.time() - t0
@@ -378,13 +375,6 @@ class Controller:
 
             # Save results
             self.export_opfs()
-
-            # Save warnings
-            folder_name = f"{SIMULATED_POWERS_DIRECTORY_ROOT}_{start_year}-{end_year}"
-            file_path = self._work_dir / folder_name / "Warnings.xlsx"
-            warnings_df = pd.DataFrame(warnings_years).transpose()
-            with pd.ExcelWriter(file_path) as writer:
-                warnings_df.to_excel(writer, sheet_name="Warnings", index=True)
 
     def export_opfs(self):
         """

--- a/src/input_reader.py
+++ b/src/input_reader.py
@@ -13,6 +13,9 @@ MAP_TO_ALPHA2_FILE_NAME = "eu_countries_alpha2_codes.xlsx"
 INTERCO_FOLDER_NAME = "interconnections_power_ratings_and_powers_2015_2019"
 INTERCO_POWER_RATINGS_FILE_NAME = "interconnections_power_ratings.xlsx"
 INTERCO_POWERS_FILE_NAME = "interconnections_powers_transferred_2015_2019.xlsx"
+STORAGE_FILE_NAME = "storages_energy_data.xlsx"
+
+GWh_to_MWh = 1000
 
 
 class InputReader:
@@ -583,3 +586,52 @@ class InputReader:
 
         self._interco_powers = pd.concat(all_years_data, ignore_index=True).sort_values("Time")
         return self._interco_powers
+
+    # ------ Storages energy ratings for OPF ------- #
+    def read_db_storages_energy_data(self):
+        """
+        Reads energy ratings per country and storage from an Excel file in the database directory.
+        Eac main sector declared as storage must have at least one of its detailed sectors which has energy ratings in
+        the database.
+
+        :return:
+            dictionary with 2 dictionaries as values. 1 for energy ratings and 1 for mean inflows:
+                dict[str, dict[str, float]]: Dictionary mapping zones names to energy rating per aggregated storage
+                dict[str, dict[str, float]]: Dictionary mapping zones names to mean inflow per aggregated storage
+        """
+        storages_energy_path = self._db_dir / STORAGE_FILE_NAME
+        storage_data = dict()
+
+        for sheet_name in ("Energy MWh", "Mean inflow MW"):
+            df = pd.read_excel(storages_energy_path, sheet_name=sheet_name)
+            assert df.columns[0] == "Country"
+            storages_names = list(df.columns[1:])
+
+            # Energy rating (or mean inflow) per country and sector
+            detailed_data = dict()  # {country name: {storage name: energy rating MWh or mean inflow MW}}
+            for _, row in df.iterrows():
+                detailed_data[row["Country"]] = {storage: row[storage] for storage in storages_names}
+
+            # Energy rating (or mean inflow) per zone and grouped sector
+            grouped_data = dict()
+            for zone, countries in self._zones.items():
+                zone_data = dict()
+                for group_name, sectors in self._sectors_group.items():
+                    if group_name in self._storages:
+                        if all([(sector not in storages_names) for sector in sectors]):
+                            raise ValueError(
+                                f"You want to consider the main sector '{group_name}' as a storage but none of its "
+                                f"detailed sectors ({sectors}) has {sheet_name} provided in {storages_energy_path}.\n"
+                                f"The possible storages are: {storages_names}"
+                            )
+                        grouped_value = 0  # for the group_name in the zone
+                        for country in countries:
+                            if country in detailed_data.keys():
+                                for sector in sectors:
+                                    if sector in detailed_data[country].keys():
+                                        grouped_value += detailed_data[country][sector]
+                        zone_data[group_name] = grouped_value
+                grouped_data[zone] = zone_data
+            storage_data[sheet_name] = grouped_data
+
+        return storage_data

--- a/src/interconnection.py
+++ b/src/interconnection.py
@@ -36,6 +36,9 @@ class Interconnection:
         # -- "Variable" attribute for OPF computation
         self._current_power = 0
 
+    def __repr__(self):
+        return f"{self._zone_from.name} -> {self._zone_to.name}"
+
     @property
     def zone_from(self):
         return self._zone_from
@@ -45,8 +48,15 @@ class Interconnection:
         return self._zone_to
 
     @property
+    def power_rating(self):
+        return self._power_rating
+
+    @property
     def historical_powers(self):
         return self._historical_powers.copy()
+
+    def historical_power(self, timestep: pd.Timestamp):
+        return self._historical_powers[timestep]
 
     def store_simulated_power(self, timestep: pd.Timestamp):
         """
@@ -243,9 +253,6 @@ class Interconnection:
             else:
                 x, cost = x12, cost12
         return x, cost
-
-    def init_current_power(self, timestep: pd.Timestamp):
-        self._current_power = self._historical_powers[timestep]
 
 
 OUT_ZONE_NAME = "OUTSIDE"

--- a/src/interconnection.py
+++ b/src/interconnection.py
@@ -276,5 +276,3 @@ class ExteriorInterconnection(Interconnection):
         Zero, as nothing is optimised here.
         """
         return 0
-
-

--- a/src/interconnection.py
+++ b/src/interconnection.py
@@ -36,7 +36,7 @@ class Interconnection:
         # -- "Variable" attribute for OPF computation
         self._current_power = 0
 
-    def __repr__(self):
+    def __str__(self):
         return f"{self._zone_from.name} -> {self._zone_to.name}"
 
     @property

--- a/src/main.py
+++ b/src/main.py
@@ -8,10 +8,10 @@ from src.controller import Controller
 
 
 if __name__ == "__main__":
-    work_dir = Path("C:/Users/b.perreyon/Documents/ECL cost models/wk dir/new")
-    db_dir = Path("C:/Users/b.perreyon/Documents/ECL cost models/database/fixed")
-    # work_dir = Path("C:/Users/n.barla/Documents/Local_codes/ecl_cost_models/instance/studies/study_1")
-    # db_dir = Path("C:/Users/n.barla/Documents/Local_codes/ecl_cost_models/instance/database/2025-08")
+    # work_dir = Path("C:/Users/b.perreyon/Documents/ECL cost models/wk dir/new")
+    # db_dir = Path("C:/Users/b.perreyon/Documents/ECL cost models/database/fixed")
+    work_dir = Path("C:/Users/n.barla/Documents/Local_codes/ecl_cost_models/instance/studies/study_1")
+    db_dir = Path("C:/Users/n.barla/Documents/Local_codes/ecl_cost_models/instance/database/2025-08")
 
     # controller = Controller(work_dir=work_dir, db_dir=db_dir)
     # controller.build_price_models()

--- a/src/network.py
+++ b/src/network.py
@@ -156,7 +156,7 @@ class Network:
         # Initialise the network (no export)
         for zone in self._zones.values():
             zone.reset_powers()
-            zone.update_storages_availability(time_step=timestep)
+            zone.update_storages_availability(timestep=timestep)
         for interco in self._interconnections:
             interco.init_current_power(timestep)
 
@@ -187,8 +187,8 @@ class Network:
 
         # Store results
         for zone in self.zones.values():
-            zone.store_simulated_power(timestep)
             zone.update_storages_energy()
+            zone.store_simulated_power(timestep)
         for interconnection in self._interconnections:
             interconnection.store_simulated_power(timestep)
 

--- a/src/network.py
+++ b/src/network.py
@@ -220,9 +220,8 @@ class Network:
             # Warning if export power in an outside interconnection is not feasible
             # (It can occur if a storage availability is inconsistent with its historical power)
             if interco in outside_interconnections and initial_export != historical_power_per_interco[interco]:
-                interco_str = interco.__repr__()  # f"{interco.zone_from.name} -> {interco.zone_to.name}"
-                outside_export_warnings[f"{interco_str} | historical_export"] = historical_export
-                outside_export_warnings[f"{interco_str} | initial_export"] = initial_export
+                outside_export_warnings[f"{interco} | historical_export"] = historical_export
+                outside_export_warnings[f"{interco} | initial_export"] = initial_export
 
         return outside_export_warnings
 

--- a/src/network.py
+++ b/src/network.py
@@ -1,7 +1,8 @@
-from numpy import inf
+import warnings
+
 import pandas as pd
 
-from src.interconnection import ExteriorInterconnection, Interconnection, OUT_ZONE_NAME
+from src.interconnection import ExteriorInterconnection, Interconnection
 from src.opf_utils import TOL, bounded_value
 from src.zone import Zone
 
@@ -160,40 +161,47 @@ class Network:
         Initialise export in each interconnection with values close to historical powers, by respecting feasible export
         per zone.
         """
+
+        def get_exterior_interconnection(inside_zone: Zone) -> ExteriorInterconnection | None:
+            # By construction, outside connection should be the last
+            for interconnection in reversed(inside_zone.interconnections):
+                if isinstance(interconnection, ExteriorInterconnection):
+                    return interconnection
+            return None  # This should not happen as each zone is connected to the exterior zone
+
         # Reset export per zone and update available power per storage
         for zone in self._zones.values():
             zone.reset_powers()
             zone.update_storages_availability(timestep=timestep)
 
-        feasible_export_per_zone = {zone: zone.feasible_export_range(timestep=timestep)
-                                    for zone in self._zones.values()}
-        historical_power_per_interco = {interco: interco.historical_power(timestep)
-                                        for interco in self._interconnections}
-
-        outside_interconnections = list()  # Interconnections between a network zone and outside the network
+        # Reset export with the outside zone and list inner network interconnection
         inside_interconnections = list()  # Interconnections between network zones
         for interco in self._interconnections:
             if isinstance(interco, ExteriorInterconnection):
-                outside_interconnections.append(interco)
+                interco.set_export(power=interco.historical_powers[timestep])
             else:
                 inside_interconnections.append(interco)
+
+        # Compute minimum and maximum export per zone, considering storage constraints and exchange with outside
+        feasible_export_per_zone = {}
+        for zone in self._zones.values():
+            min_net_export, max_net_export = zone.feasible_export_range(timestep)
+            exterior_interco = get_exterior_interconnection(zone)
+            if exterior_interco is not None:
+                external_net_export = exterior_interco.get_export(zone)  # Is equal to historical power
+                min_net_export -= external_net_export
+                max_net_export -= external_net_export
+
+            feasible_export_per_zone[zone] = min_net_export, max_net_export
+
+        historical_power_per_interco = {interco: interco.historical_power(timestep)
+                                        for interco in self._interconnections}
 
         # Export per zone due to initial export per interconnection
         requested_export_per_zone = {zone: 0 for zone in self._zones.values()}
 
-        # Add the zone representing outside the network
-        if len(outside_interconnections) > 0:
-            outside_interco = outside_interconnections[0]
-            if outside_interco.zone_to.name == OUT_ZONE_NAME:
-                outside_zone = outside_interco.zone_to
-            else:
-                assert outside_interco.zone_from.name == OUT_ZONE_NAME
-                outside_zone = outside_interco.zone_from
-            feasible_export_per_zone[outside_zone] = (-inf, inf)
-            requested_export_per_zone[outside_zone] = 0
-
-        outside_export_warnings = dict()
-        for interco in outside_interconnections + inside_interconnections:
+        # Set initial power in interconnections allowing to respect export constraints
+        for interco in inside_interconnections:
             # Feasible export per zone
             zone_from = interco.zone_from
             zone_to = interco.zone_to
@@ -211,19 +219,31 @@ class Network:
 
             # Initialise the export in the interconnection
             historical_export = historical_power_per_interco[interco]
-            initial_export = bounded_value(value=historical_export,
-                                           min_value=min_export, max_value=max_export)
+            initial_export = bounded_value(
+                value=bounded_value(value=historical_export, min_value=min_export, max_value=max_export),
+                min_value=-interco.power_rating, max_value=interco.power_rating
+            )
             interco.set_export(power=initial_export)
             requested_export_per_zone[zone_from] += initial_export
             requested_export_per_zone[zone_to] -= initial_export
 
-            # Warning if export power in an outside interconnection is not feasible
-            # (It can occur if a storage availability is inconsistent with its historical power)
-            if interco in outside_interconnections and initial_export != historical_power_per_interco[interco]:
-                outside_export_warnings[f"{interco} | historical_export"] = historical_export
-                outside_export_warnings[f"{interco} | initial_export"] = initial_export
+        # Check requested export per zone is within allowed limits
+        for zone, requested_export in requested_export_per_zone.items():
+            min_net_export, max_net_export = feasible_export_per_zone[zone]
+            if not (min_net_export <= requested_export <= max_net_export):
+                # For the OPF to initialise, we modify the interconnection with the exterior, thus artificially
+                # falsifying the simulation inputs.
+                exterior_interconnection = get_exterior_interconnection(zone)
+                assert exterior_interconnection is not None
 
-        return outside_export_warnings
+                if requested_export > max_net_export:
+                    delta_power = max_net_export - requested_export  # <0, power to remove in exterior interconnection
+                else:
+                    delta_power = min_net_export - requested_export  # >0, power to add in exterior interconnection
+                exterior_interconnection.set_export(exterior_interconnection.get_export(zone) + delta_power)
+                warnings.warn(f"At timestep {timestep}, zone {zone.name} export constraints could not be satisfied. "
+                              f"Interconnection with the outside zone is modified by {delta_power}, therefore "
+                              "simulation results cannot be compared with historical data", stacklevel=2)
 
     def run_opf(self, timestep: pd.Timestamp):
         """
@@ -232,7 +252,7 @@ class Network:
 
         # Export in each interconnection are initialised close to historical.
         # Warnings are returned if outside interconnections do not export their historical power.
-        outside_interco_warnings = self.initialise_opf(timestep=timestep)
+        self.initialise_opf(timestep=timestep)
 
         # Run market in each zone
         for zone in self._zones.values():
@@ -253,7 +273,7 @@ class Network:
             i += 1
 
         if not converged:
-            return False, outside_interco_warnings  # The OPF did not converge
+            return False  # The OPF did not converge
 
         # Run market in each zone with the final exports
         for zone in self._zones.values():
@@ -266,4 +286,4 @@ class Network:
         for interconnection in self._interconnections:
             interconnection.store_simulated_power(timestep)
 
-        return True, outside_interco_warnings
+        return True

--- a/src/network.py
+++ b/src/network.py
@@ -1,7 +1,8 @@
+from numpy import inf
 import pandas as pd
 
-from src.interconnection import ExteriorInterconnection, Interconnection
-from src.opf_utils import TOL
+from src.interconnection import ExteriorInterconnection, Interconnection, OUT_ZONE_NAME
+from src.opf_utils import TOL, bounded_value
 from src.zone import Zone
 
 
@@ -42,8 +43,7 @@ class Network:
         self._datetime_index = self._datetime_index.drop(invalid_datetime)
 
     def add_zone(self, zone_name: str, sectors_historical_powers: pd.DataFrame, storages: list[str],
-                 controllable_sectors: list[str], historical_prices: pd.Series,
-                 energy_ratings: dict, mean_inflows: dict):
+                 controllable_sectors: list[str], historical_prices: pd.Series):
         """
         Adds a new zone to the network with its sectors and storages, it includes all the powers data for the sectors
         and all the prices data for the zone
@@ -53,8 +53,6 @@ class Network:
         :param storages: List of sector names that are storages
         :param controllable_sectors: List of sector names that are controllable
         :param historical_prices: Historical prices for the zone
-        :param energy_ratings: Energy rating per storage. Used to run OPF but not to build price models.
-        :param mean_inflows: Constant natural charging per storage
         """
         zone = Zone(zone_name, historical_prices)
         self._zones[zone_name] = zone
@@ -77,9 +75,7 @@ class Network:
             is_controllable = sector_name in controllable_sectors
             if sector_name in storages:
                 zone.add_storage(sector_name, sectors_historical_powers[sector_name], is_controllable,
-                                 opf_mode=self._is_opf_mode,
-                                 # energy_rating is not necessary to build price models
-                                 energy_rating=energy_ratings.get(zone, 0), mean_inflow=mean_inflows.get(zone, 0))
+                                 opf_mode=self._is_opf_mode)
             else:
                 zone.add_sector(sector_name, sectors_historical_powers[sector_name], is_controllable)
 
@@ -104,7 +100,7 @@ class Network:
 
     def add_exterior_interconnection(self, zone_from: Zone, zone_to: Zone, historical_power_flows: pd.Series):
         """
-        Add a interconnection with the 'Exterior' zone.
+        Add an interconnection with the 'Exterior' zone.
 
         Parameters
         ----------
@@ -145,20 +141,99 @@ class Network:
             zone_price_models = price_models[zone_name]
             zone.set_price_model(zone_price_models)
 
-    def run_opf(self, timestep: pd.Timestamp):
+    def build_storage_constraints(self, energy_ratings: dict, mean_inflows: dict):
         """
-        Runs the Optimal Power Flow (OPF) algorithm on the network
+        Build min/max energy constraint time series for each storage.
 
-        Note:
-            Method currently not implemented
+        Parameters
+        ----------
+        energy_ratings: Energy rating per storage. Used to run OPF but not to build price models
+        mean_inflows: Constant natural charging per storage
         """
+        for zone_name, zone in self._zones.items():
+            zone.build_storage_constraints(datetime_index=self._datetime_index,
+                                           energy_ratings=energy_ratings[zone_name],
+                                           mean_inflows=mean_inflows[zone_name])
 
-        # Initialise the network (no export)
+    def initialise_opf(self, timestep):
+        """
+        Initialise export in each interconnection with values close to historical powers, by respecting feasible export
+        per zone.
+        """
+        # Reset export per zone and update available power per storage
         for zone in self._zones.values():
             zone.reset_powers()
             zone.update_storages_availability(timestep=timestep)
+
+        feasible_export_per_zone = {zone: zone.feasible_export_range(timestep=timestep)
+                                    for zone in self._zones.values()}
+        historical_power_per_interco = {interco: interco.historical_power(timestep)
+                                        for interco in self._interconnections}
+
+        outside_interconnections = list()  # Interconnections between a network zone and outside the network
+        inside_interconnections = list()  # Interconnections between network zones
         for interco in self._interconnections:
-            interco.init_current_power(timestep)
+            if isinstance(interco, ExteriorInterconnection):
+                outside_interconnections.append(interco)
+            else:
+                inside_interconnections.append(interco)
+
+        # Export per zone due to initial export per interconnection
+        requested_export_per_zone = {zone: 0 for zone in self._zones.values()}
+
+        # Add the zone representing outside the network
+        if len(outside_interconnections) > 0:
+            outside_interco = outside_interconnections[0]
+            if outside_interco.zone_to.name == OUT_ZONE_NAME:
+                outside_zone = outside_interco.zone_to
+            else:
+                assert outside_interco.zone_from.name == OUT_ZONE_NAME
+                outside_zone = outside_interco.zone_from
+            feasible_export_per_zone[outside_zone] = (-inf, inf)
+            requested_export_per_zone[outside_zone] = 0
+
+        outside_export_warnings = dict()
+        for interco in outside_interconnections + inside_interconnections:
+            # Feasible export per zone
+            zone_from = interco.zone_from
+            zone_to = interco.zone_to
+            min_from, max_from = feasible_export_per_zone[zone_from]
+            min_to, max_to = feasible_export_per_zone[zone_to]
+
+            # Feasible export in the interconnection
+            min_from -= requested_export_per_zone[zone_from]
+            max_from -= requested_export_per_zone[zone_from]
+            min_to -= requested_export_per_zone[zone_to]
+            max_to -= requested_export_per_zone[zone_to]
+            min_export = max(min_from, - max_to)
+            max_export = min(max_from, - min_to)
+            assert max_export >= min_export
+
+            # Initialise the export in the interconnection
+            historical_export = historical_power_per_interco[interco]
+            initial_export = bounded_value(value=historical_export,
+                                           min_value=min_export, max_value=max_export)
+            interco.set_export(power=initial_export)
+            requested_export_per_zone[zone_from] += initial_export
+            requested_export_per_zone[zone_to] -= initial_export
+
+            # Warning if export power in an outside interconnection is not feasible
+            # (It can occur if a storage availability is inconsistent with its historical power)
+            if interco in outside_interconnections and initial_export != historical_power_per_interco[interco]:
+                interco_str = interco.__repr__()  # f"{interco.zone_from.name} -> {interco.zone_to.name}"
+                outside_export_warnings[f"{interco_str} | historical_export"] = historical_export
+                outside_export_warnings[f"{interco_str} | initial_export"] = initial_export
+
+        return outside_export_warnings
+
+    def run_opf(self, timestep: pd.Timestamp):
+        """
+        Runs the Optimal Power Flow (OPF) algorithm on the network
+        """
+
+        # Export in each interconnection are initialised close to historical.
+        # Warnings are returned if outside interconnections do not export their historical power.
+        outside_interco_warnings = self.initialise_opf(timestep=timestep)
 
         # Run market in each zone
         for zone in self._zones.values():
@@ -179,7 +254,7 @@ class Network:
             i += 1
 
         if not converged:
-            return False  # The OPF did not converge
+            return False, outside_interco_warnings  # The OPF did not converge
 
         # Run market in each zone with the final exports
         for zone in self._zones.values():
@@ -192,13 +267,4 @@ class Network:
         for interconnection in self._interconnections:
             interconnection.store_simulated_power(timestep)
 
-        return True
-
-    def check_power_models(self):
-        """
-        Validates power models for each sector or interconnection
-
-        Note:
-            Method currently not implemented (will be for OPF).
-        """
-        pass
+        return True, outside_interco_warnings

--- a/src/network.py
+++ b/src/network.py
@@ -42,7 +42,8 @@ class Network:
         self._datetime_index = self._datetime_index.drop(invalid_datetime)
 
     def add_zone(self, zone_name: str, sectors_historical_powers: pd.DataFrame, storages: list[str],
-                 controllable_sectors: list[str], historical_prices: pd.Series):
+                 controllable_sectors: list[str], historical_prices: pd.Series,
+                 energy_ratings: dict, mean_inflows: dict):
         """
         Adds a new zone to the network with its sectors and storages, it includes all the powers data for the sectors
         and all the prices data for the zone
@@ -52,6 +53,8 @@ class Network:
         :param storages: List of sector names that are storages
         :param controllable_sectors: List of sector names that are controllable
         :param historical_prices: Historical prices for the zone
+        :param energy_ratings: Energy rating per storage. Used to run OPF but not to build price models.
+        :param mean_inflows: Constant natural charging per storage
         """
         zone = Zone(zone_name, historical_prices)
         self._zones[zone_name] = zone
@@ -74,7 +77,9 @@ class Network:
             is_controllable = sector_name in controllable_sectors
             if sector_name in storages:
                 zone.add_storage(sector_name, sectors_historical_powers[sector_name], is_controllable,
-                                 opf_mode=self._is_opf_mode)
+                                 opf_mode=self._is_opf_mode,
+                                 # energy_rating is not necessary to build price models
+                                 energy_rating=energy_ratings.get(zone, 0), mean_inflow=mean_inflows.get(zone, 0))
             else:
                 zone.add_sector(sector_name, sectors_historical_powers[sector_name], is_controllable)
 
@@ -151,6 +156,7 @@ class Network:
         # Initialise the network (no export)
         for zone in self._zones.values():
             zone.reset_powers()
+            zone.update_storages_availability(time_step=timestep)
         for interco in self._interconnections:
             interco.init_current_power(timestep)
 
@@ -182,6 +188,7 @@ class Network:
         # Store results
         for zone in self.zones.values():
             zone.store_simulated_power(timestep)
+            zone.update_storages_energy()
         for interconnection in self._interconnections:
             interconnection.store_simulated_power(timestep)
 

--- a/src/network.py
+++ b/src/network.py
@@ -215,7 +215,8 @@ class Network:
             max_to -= requested_export_per_zone[zone_to]
             min_export = max(min_from, - max_to)
             max_export = min(max_from, - min_to)
-            assert max_export >= min_export
+            if min_export > max_export:
+                min_export = max_export
 
             # Initialise the export in the interconnection
             historical_export = historical_power_per_interco[interco]

--- a/src/sector.py
+++ b/src/sector.py
@@ -80,7 +80,7 @@ class Sector:
 
     @property
     def simulated_powers(self):
-        """Returns the sector stimulated power time series"""
+        """Returns the sector simulated power time series"""
         return self._simulated_powers
 
     @property

--- a/src/sector.py
+++ b/src/sector.py
@@ -31,9 +31,14 @@ class Sector:
         self._price_model = tuple()  # (price_no_power, price_full_power) in €/MWh
         self._is_controllable = is_controllable
         self._is_load = is_load
+        if is_load:
+            self._power_rating = - historical_powers.min()  # useful for storages
+        else:
+            self._power_rating = historical_powers.max()
 
         self._simulated_powers = pd.Series()  # in MW
-        self._availabilities = pd.Series()  # in MW
+        self._availabilities = pd.Series()  # in MW, built before the simulation if not storage
+        self._available_power: float | None = None  # in MW, updated each hour if storage
 
         # -- "Variable" attribute for OPF computation
         self._current_power = 0
@@ -54,18 +59,28 @@ class Sector:
         return self._is_load
 
     @property
+    def power_rating(self) -> float:  # > 0
+        return self._power_rating
+
+    @property
     def historical_powers(self):
         """Returns the sector historical power time series"""
         return self._historical_powers.copy()
 
-    @property
-    def available_powers(self):
-        """Returns the sector available power time series"""
-        return self._availabilities.copy()
+    def set_available_power(self, power: float):
+        self._available_power = power
+
+    def available_power(self, timestep: pd.Timestamp):
+        """Returns the sector available power at the required time step"""
+        if len(self._availabilities) == 0:  # Sector is a storage
+            assert self._available_power is not None
+            return self._available_power
+        else:
+            return self._availabilities[timestep]
 
     @property
     def simulated_powers(self):
-        """Returns the sector historical power time series"""
+        """Returns the sector stimulated power time series"""
         return self._simulated_powers
 
     @property
@@ -322,15 +337,16 @@ class Sector:
             plt.savefig(path)
             plt.close()
 
-    def store_simulated_power(self, timestep: pd.Timestamp):
+    def store_simulated_power(self, timestep: pd.Timestamp, extra_power: float = 0):
         """
         Updates the simulated powers series (produced by the sector) by storing the current power stored in
         self._current_power and calculated during the OPF at the specified timestep and then resets the current
         power to zero (so that the next timesteps data can be saved)
 
         :param timestep: The timestep at which the current power should be recorded
+        :param extra_power: If storage -> constrained production (if generator) or constrained consumption (if load)
         """
-        self._simulated_powers[timestep] = self._current_power
+        self._simulated_powers[timestep] = self._current_power + extra_power
         self._current_power = 0
 
     @property

--- a/src/sector.py
+++ b/src/sector.py
@@ -6,6 +6,8 @@ import pandas as pd
 from matplotlib import pyplot as plt
 from scipy.optimize import minimize
 
+from src.opf_utils import TOL
+
 
 class Sector:
     """
@@ -67,7 +69,10 @@ class Sector:
         """Returns the sector historical power time series"""
         return self._historical_powers.copy()
 
-    def set_available_power(self, power: float):
+    def set_available_power(self, power: float):  # >= 0
+        assert power >= - TOL
+        if power <= TOL:
+            power = 0
         self._available_power = power
 
     def available_power(self, timestep: pd.Timestamp):

--- a/src/storage.py
+++ b/src/storage.py
@@ -29,7 +29,7 @@ class Storage:
         self._consumption_efficiency = consumption_efficiency
         self._stored_energy: float = energy_rating / 2  #: energy at the beginning of the hour
         self._next_energy: float | None = None  #: energy at the end of the hour
-        self.time_step_to_hour = {time_step: i for i, time_step in enumerate(historical_powers.index)}
+        self._timestep_to_hour = {timestep: i for i, timestep in enumerate(historical_powers.index)}
         self._current_hour = 0
         self._n_hours = len(historical_powers)
         self._constrained_production = 0  # MW, < 0 if constrained consumption
@@ -96,16 +96,16 @@ class Storage:
         """
         return self._constrained_production
 
-    def update_availabilities(self, time_step: pd.Timestamp):
+    def update_availabilities(self, timestep: pd.Timestamp):
         """
         Update the available power of the storage load and generator and the storage constrained production based on
         its energy level and constraints.
 
         Parameters
         ----------
-        time_step: Must be coherent with self._current_hour
+        timestep: Must be coherent with self._current_hour
         """
-        assert self._current_hour == self.time_step_to_hour[time_step]  # int
+        assert self._current_hour == self._timestep_to_hour[timestep]  # int
 
         (min_expected_energy, max_expected_energy) = self._energy_constraints[self._current_hour]
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -90,7 +90,7 @@ class Storage:
         charging_rating = consumption_rating_mw * self._consumption_efficiency
         discharging_rating = production_rating_mw / self._production_efficiency
 
-        if not (- charging_rating <= mean_inflow <= discharging_rating):
+        if not (0 <= mean_inflow <= discharging_rating):
             feasible_inflow = bounded_value(value=mean_inflow, min_value=-charging_rating, max_value=discharging_rating)
             warnings.warn(f"Storage {self._name}: mean inflow set to {feasible_inflow} instead of {mean_inflow} to be "
                           f"compatible with charging ({charging_rating} and discharging ({discharging_rating}) ratings")
@@ -130,7 +130,7 @@ class Storage:
         timestep: The current timestep (used to identify energy constraints)
         """
         self._timestep = timestep
-        (min_expected_energy, max_expected_energy) = self._energy_constraints.loc[timestep]
+        min_expected_energy, max_expected_energy = self._energy_constraints.loc[timestep]
 
         # Allowed net production to keep min_expected_energy <= stored energy <= max_expected_energy
         allowed_production = min(
@@ -166,7 +166,7 @@ class Storage:
         Computes stored energy at current hour + 59 mn
         """
         assert self._next_energy is None
-        (min_expected_energy, max_expected_energy) = self._energy_constraints.loc[self._timestep]
+        min_expected_energy, max_expected_energy = self._energy_constraints.loc[self._timestep]
 
         net_production = self._constrained_production + self.generator.current_power - self.load.current_power
         if net_production >= 0:

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,5 +1,6 @@
 import pandas as pd
 
+from src.opf_utils import TOL
 from src.sector import Sector
 
 
@@ -9,15 +10,30 @@ class Storage:
         one acting as a load (charging) and the other as a generator (discharging).
     """
 
-    def __init__(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool):
+    def __init__(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool,
+                 energy_rating: float, mean_inflow: float, production_efficiency=1., consumption_efficiency=1.):
         """
         Initializes the Storage instance by splitting historical power data into load (negative powers) and
         generator sectors (positive powers).
 
         :param sector_name: Name of the sectors associated with this storage
         :param historical_powers: Time series of historical power values (can be positive or negative)
-        :param is_controllable : Indicates whether the storage system is controllable
+        :param is_controllable: Indicates whether the storage system is controllable
+        :param energy_rating: Energy rating (in MW) of the storage. Used to run OPF but not to build price models.
+        :param production_efficiency: Between 0 & 1 (Electrical production / Stored energy decrease)
+        :param consumption_efficiency: Between 0 & 1 (Stored energy increase / Electrical consumption)
         """
+        self._energy_rating = energy_rating
+        self._mean_inflow = mean_inflow
+        self._production_efficiency = production_efficiency
+        self._consumption_efficiency = consumption_efficiency
+        self._stored_energy: float = energy_rating / 2  #: energy at the beginning of the hour
+        self._next_energy: float | None = None  #: energy at the end of the hour
+        self.time_step_to_hour = {time_step: i for i, time_step in enumerate(historical_powers.index)}
+        self._current_hour = 0
+        self._n_hours = len(historical_powers)
+        self._constrained_production = 0  # MW, < 0 if constrained consumption
+
         if opf_mode:
             # In OPF mode, all timestamp are kept.
             # They are replaced by zero when the storage behaves in the opposite operating mode.
@@ -31,6 +47,11 @@ class Storage:
         self._load = Sector(sector_name, powers_load, is_controllable=is_controllable, is_load=True)
         self._generator = Sector(sector_name, powers_generator, is_controllable=is_controllable)
 
+        if opf_mode:
+            self._energy_constraints = self._build_energy_constraints()
+        else:
+            self._energy_constraints = list()
+
     @property
     def load(self):
         return self._load
@@ -38,3 +59,107 @@ class Storage:
     @property
     def generator(self):
         return self._generator
+
+    def _build_energy_constraints(self):
+        """
+        Compute time series of min/max energy requirements to ensure no stored energy change between start and end of
+        the simulation (initial energy = final energy).
+
+        Returns
+        -------
+        List of (min energy, max energy) to be respected by the stored energy
+        """
+        # assert len(self._energy_constraints) == 0
+        consumption_rating_mw = self._load.power_rating  # >= 0
+        production_rating_mw = self._generator.power_rating
+        last_energy = self._energy_rating / 2  # = initial energy
+        energy_constraints = list()
+        for i in range(self._n_hours):
+            next_hours = self._n_hours - i - 1
+            # Compute possible storing next hours
+            future_inflow = self._mean_inflow * next_hours
+            max_storing = consumption_rating_mw * self._consumption_efficiency * next_hours
+            max_unstoring = production_rating_mw / self._production_efficiency * next_hours
+            max_future_reasonable_storing = future_inflow + max_storing / 2  # max_storing/2 to keep margin
+            min_future_reasonable_storing = future_inflow - max_unstoring / 2
+
+            min_energy = max(0., last_energy - max_future_reasonable_storing)
+            max_energy = min(self._energy_rating, last_energy - min_future_reasonable_storing)
+
+            energy_constraints.append((min_energy, max_energy))
+        return energy_constraints
+
+    @property
+    def constrained_production(self) -> float:
+        """
+        Returns production (consumption if < 0) required to ensure min/max stored energy next hour
+        """
+        return self._constrained_production
+
+    def update_availabilities(self, time_step: pd.Timestamp):
+        """
+        Update the available power of the storage load and generator and the storage constrained production based on
+        its energy level and constraints.
+
+        Parameters
+        ----------
+        time_step: Must be coherent with self._current_hour
+        """
+        assert self._current_hour == self.time_step_to_hour[time_step]  # int
+
+        (min_expected_energy, max_expected_energy) = self._energy_constraints[self._current_hour]
+
+        # Allowed net production to keep min_expected_energy <= stored energy <= max_expected_energy
+        allowed_production = min(
+            self.generator.power_rating,
+            (self._stored_energy + self._mean_inflow - min_expected_energy) * self._production_efficiency)
+        allowed_consumption = min(
+            self.load.power_rating,
+            (max_expected_energy - (self._stored_energy + self._mean_inflow)) / self._consumption_efficiency)
+
+        # Constrained net production to keep min_expected_energy <= stored energy <= max_expected_energy
+        if self._stored_energy + self._mean_inflow > max_expected_energy + TOL:
+            # Storage too full: need to produce (no consumption)
+            self._constrained_production = min(
+                self.generator.power_rating,
+                (self._stored_energy + self._mean_inflow - max_expected_energy) * self._production_efficiency)  # > 0
+            self.generator.set_available_power(power=allowed_production - self._constrained_production)
+            self.load.set_available_power(power=0)
+        elif self._stored_energy + self._mean_inflow < min_expected_energy - TOL:
+            # Storage too empty: need to consume (no production)
+            self._constrained_production = - min(self.load.power_rating,
+                                                 (min_expected_energy - self._stored_energy - self._mean_inflow)
+                                                 / self._consumption_efficiency)  # < 0
+            self.generator.set_available_power(power=0)
+            self.load.set_available_power(power=allowed_consumption + self._constrained_production)
+        else:
+            # Possible to consume or to produce
+            self._constrained_production = 0
+            self.generator.set_available_power(power=allowed_production)
+            self.load.set_available_power(power=allowed_consumption)
+
+    def _compute_new_energy(self):
+        """
+        Computes stored energy at current hour + 59 mn
+        """
+        assert self._next_energy is None
+        (min_expected_energy, max_expected_energy) = self._energy_constraints[self._current_hour]
+
+        net_production = self._constrained_production + self.generator.current_power - self.load.current_power
+        if net_production >= 0:
+            new_energy = self._stored_energy + self._mean_inflow - net_production / self._production_efficiency
+        else:
+            new_energy = self._stored_energy + self._mean_inflow - net_production * self._consumption_efficiency
+        assert (min_expected_energy - TOL <= new_energy <= max_expected_energy + TOL)
+        assert -TOL <= new_energy <= self._energy_rating + TOL
+        self._next_energy = min(new_energy, self._energy_rating)
+
+    def update_energy(self):
+        """
+        Update current hour and stored energy (as 1 hour has passed)
+        """
+        if self._next_energy is None:
+            self._compute_new_energy()
+        self._stored_energy = self._next_energy
+        self._next_energy = None
+        self._current_hour += 1

--- a/src/storage.py
+++ b/src/storage.py
@@ -90,11 +90,10 @@ class Storage:
         charging_rating = consumption_rating_mw * self._consumption_efficiency
         discharging_rating = production_rating_mw / self._production_efficiency
 
-        if not (0 <= mean_inflow <= discharging_rating):
-            feasible_inflow = bounded_value(value=mean_inflow, min_value=-charging_rating, max_value=discharging_rating)
-            warnings.warn(f"Storage {self._name}: mean inflow set to {feasible_inflow} instead of {mean_inflow} to be "
-                          f"compatible with charging ({charging_rating} and discharging ({discharging_rating}) ratings")
-            mean_inflow = feasible_inflow
+        if mean_inflow > discharging_rating:
+            warnings.warn(f"Storage {self._name}: mean inflow set to {discharging_rating} instead of {mean_inflow} to "
+                          f"be compatible with discharging rating")
+            mean_inflow = discharging_rating
         self._mean_inflow = mean_inflow
 
         self._stored_energy = energy_rating / 2  # = initial energy

--- a/src/storage.py
+++ b/src/storage.py
@@ -1,6 +1,8 @@
+import warnings
+
 import pandas as pd
 
-from src.opf_utils import TOL
+from src.opf_utils import TOL, bounded_value
 from src.sector import Sector
 
 
@@ -11,7 +13,7 @@ class Storage:
     """
 
     def __init__(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool,
-                 energy_rating: float, mean_inflow: float, production_efficiency=1., consumption_efficiency=1.):
+                 production_efficiency=1., consumption_efficiency=1.):
         """
         Initializes the Storage instance by splitting historical power data into load (negative powers) and
         generator sectors (positive powers).
@@ -19,20 +21,23 @@ class Storage:
         :param sector_name: Name of the sectors associated with this storage
         :param historical_powers: Time series of historical power values (can be positive or negative)
         :param is_controllable: Indicates whether the storage system is controllable
-        :param energy_rating: Energy rating (in MW) of the storage. Used to run OPF but not to build price models.
         :param production_efficiency: Between 0 & 1 (Electrical production / Stored energy decrease)
         :param consumption_efficiency: Between 0 & 1 (Stored energy increase / Electrical consumption)
         """
-        self._energy_rating = energy_rating
-        self._mean_inflow = mean_inflow
+        self._name = sector_name
         self._production_efficiency = production_efficiency
         self._consumption_efficiency = consumption_efficiency
-        self._stored_energy: float = energy_rating / 2  #: energy at the beginning of the hour
-        self._next_energy: float | None = None  #: energy at the end of the hour
-        self._timestep_to_hour = {timestep: i for i, timestep in enumerate(historical_powers.index)}
-        self._current_hour = 0
-        self._n_hours = len(historical_powers)
+
+        # Updated in build_energy_constraints
+        self._energy_rating: float | None = None
+        self._mean_inflow: float | None = None
+        self._energy_constraints = pd.DataFrame()
+
+        # Updated each hour
+        self._timestep: pd.Timestamp | None = None
         self._constrained_production = 0  # MW, < 0 if constrained consumption
+        self._stored_energy: float | None = None
+        self._next_energy: float | None = None  #: energy at the end of the hour
 
         if opf_mode:
             # In OPF mode, all timestamp are kept.
@@ -47,10 +52,9 @@ class Storage:
         self._load = Sector(sector_name, powers_load, is_controllable=is_controllable, is_load=True)
         self._generator = Sector(sector_name, powers_generator, is_controllable=is_controllable)
 
-        if opf_mode:
-            self._energy_constraints = self._build_energy_constraints()
-        else:
-            self._energy_constraints = list()
+    @property
+    def name(self):
+        return self._name
 
     @property
     def load(self):
@@ -60,34 +64,54 @@ class Storage:
     def generator(self):
         return self._generator
 
-    def _build_energy_constraints(self):
+    def build_energy_constraints(self, datetime_index: list[pd.Timestamp], energy_rating: float, mean_inflow: float,
+                                 reasonable_forced_power_factor: float = 0.5):
         """
         Compute time series of min/max energy requirements to ensure no stored energy change between start and end of
         the simulation (initial energy = final energy).
+
+        Parameters
+        ----------
+        datetime_index: Time steps for which an OPF will be run
+        energy_rating: Energy rating of the storage. Stored energy is initialised at half of it.
+        mean_inflow: Constant natural charging
+        reasonable_forced_power_factor: The final stored energy must be equal to the initial one. At the end of the
+                                        simulation the storage is forced to consume (or produce) if its stored power is
+                                        too low (or high). This ratio (between 0 and 1) is a maximum for
+                                        constrained power / power rating.
 
         Returns
         -------
         List of (min energy, max energy) to be respected by the stored energy
         """
-        # assert len(self._energy_constraints) == 0
+        self._energy_rating = energy_rating
         consumption_rating_mw = self._load.power_rating  # >= 0
         production_rating_mw = self._generator.power_rating
-        last_energy = self._energy_rating / 2  # = initial energy
+        charging_rating = consumption_rating_mw * self._consumption_efficiency
+        discharging_rating = production_rating_mw / self._production_efficiency
+
+        if not (- charging_rating <= mean_inflow <= discharging_rating):
+            feasible_inflow = bounded_value(value=mean_inflow, min_value=-charging_rating, max_value=discharging_rating)
+            warnings.warn(f"Storage {self._name}: mean inflow set to {feasible_inflow} instead of {mean_inflow} to be "
+                          f"compatible with charging ({charging_rating} and discharging ({discharging_rating}) ratings")
+            mean_inflow = feasible_inflow
+        self._mean_inflow = mean_inflow
+
+        self._stored_energy = energy_rating / 2  # = initial energy
+        last_energy = self._stored_energy  # Consistency between initial energy and final energy
         energy_constraints = list()
-        for i in range(self._n_hours):
-            next_hours = self._n_hours - i - 1
-            # Compute possible storing next hours
+        n_hours = len(datetime_index)
+        for i in range(n_hours):
+            next_hours = n_hours - i - 1
             future_inflow = self._mean_inflow * next_hours
-            max_storing = consumption_rating_mw * self._consumption_efficiency * next_hours
-            max_unstoring = production_rating_mw / self._production_efficiency * next_hours
-            max_future_reasonable_storing = future_inflow + max_storing / 2  # max_storing/2 to keep margin
-            min_future_reasonable_storing = future_inflow - max_unstoring / 2
-
-            min_energy = max(0., last_energy - max_future_reasonable_storing)
-            max_energy = min(self._energy_rating, last_energy - min_future_reasonable_storing)
-
+            max_reasonable_charging = charging_rating * next_hours * reasonable_forced_power_factor
+            max_reasonable_discharging = discharging_rating * next_hours * reasonable_forced_power_factor
+            min_energy = bounded_value(value=last_energy - future_inflow - max_reasonable_charging,
+                                       min_value=0, max_value=last_energy)
+            max_energy = bounded_value(value=last_energy - future_inflow + max_reasonable_discharging,
+                                       min_value=last_energy, max_value=self._energy_rating)
             energy_constraints.append((min_energy, max_energy))
-        return energy_constraints
+        self._energy_constraints = pd.DataFrame(energy_constraints, columns=["Min", "Max"], index=datetime_index)
 
     @property
     def constrained_production(self) -> float:
@@ -103,11 +127,10 @@ class Storage:
 
         Parameters
         ----------
-        timestep: Must be coherent with self._current_hour
+        timestep: The current timestep (used to identify energy constraints)
         """
-        assert self._current_hour == self._timestep_to_hour[timestep]  # int
-
-        (min_expected_energy, max_expected_energy) = self._energy_constraints[self._current_hour]
+        self._timestep = timestep
+        (min_expected_energy, max_expected_energy) = self._energy_constraints.loc[timestep]
 
         # Allowed net production to keep min_expected_energy <= stored energy <= max_expected_energy
         allowed_production = min(
@@ -143,15 +166,19 @@ class Storage:
         Computes stored energy at current hour + 59 mn
         """
         assert self._next_energy is None
-        (min_expected_energy, max_expected_energy) = self._energy_constraints[self._current_hour]
+        (min_expected_energy, max_expected_energy) = self._energy_constraints.loc[self._timestep]
 
         net_production = self._constrained_production + self.generator.current_power - self.load.current_power
         if net_production >= 0:
             new_energy = self._stored_energy + self._mean_inflow - net_production / self._production_efficiency
         else:
             new_energy = self._stored_energy + self._mean_inflow - net_production * self._consumption_efficiency
-        assert (min_expected_energy - TOL <= new_energy <= max_expected_energy + TOL)
-        assert -TOL <= new_energy <= self._energy_rating + TOL
+        error_info = (f"Stored energy: {self._stored_energy}. Mean inflow: {self._mean_inflow}. "
+                      f"Net production: {net_production}")
+        if not (min_expected_energy - TOL <= new_energy <= max_expected_energy + TOL):
+            raise ValueError(f"{min_expected_energy} <= {new_energy} <= {max_expected_energy}\n{error_info}")
+        if not (-TOL <= new_energy <= self._energy_rating + TOL):
+            raise ValueError(f"0 <= {new_energy} <= {self._energy_rating}\n{error_info}")
         self._next_energy = min(new_energy, self._energy_rating)
 
     def update_energy(self):
@@ -162,4 +189,3 @@ class Storage:
             self._compute_new_energy()
         self._stored_energy = self._next_energy
         self._next_energy = None
-        self._current_hour += 1

--- a/src/zone.py
+++ b/src/zone.py
@@ -445,9 +445,9 @@ class Zone:
         self._current_export = 0
         self._current_cost_function = None
 
-    def update_storages_availability(self, time_step: pd.Timestamp):
+    def update_storages_availability(self, timestep: pd.Timestamp):
         for storage in self._storages:
-            storage.update_availabilities(time_step=time_step)
+            storage.update_availabilities(timestep=timestep)
 
     def update_storages_energy(self):
         for storage in self._storages:

--- a/src/zone.py
+++ b/src/zone.py
@@ -136,7 +136,7 @@ class Zone:
             if isinstance(net_imports, pd.Series):
                 net_imports_clean = net_imports.fillna(0)
             else:  # if net_import is None or 0
-                net_imports_clean = pd.Series(0, index=zone_production.index)
+                net_imports_clean = pd.Series(0, index=zone_production.index)  # noqa (zone_production is a series)
 
             self._power_demand = net_imports_clean + zone_production
 
@@ -149,8 +149,7 @@ class Zone:
             negative_demand = self._power_demand[self._power_demand < 0]
             return negative_demand.index
 
-    def add_storage(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool,
-                    energy_rating: float, mean_inflow: float):
+    def add_storage(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool):
         """
         Adds an energy storage unit to the zone. Updates the list of sectors accordingly.
         This includes both the charging (load) and discharging (generator) components that have the same sector name
@@ -158,15 +157,31 @@ class Zone:
         :param sector_name: Name of the storage unit
         :param historical_powers: Power time series of the storage (consumption and generation) in MW
         :param is_controllable: Indicates whether the storage behavior is controllable
-        :param energy_rating: Energy rating (in MW) of the storage. Used to run OPF but not to build price models.
-        :param mean_inflow: constant natural charging of the storage
+        :param opf_mode: True if an OPF will be run. False if price models will be built.
         """
-        storage = Storage(sector_name, historical_powers, is_controllable, opf_mode=opf_mode,
-                          energy_rating=energy_rating, mean_inflow=mean_inflow)
+        storage = Storage(sector_name, historical_powers, is_controllable, opf_mode=opf_mode)
         self._storages.append(storage)
         # Availabilities are not built for storage
         self.sectors.append(storage.load)
         self.sectors.append(storage.generator)
+
+    def build_storage_constraints(self, datetime_index: list[pd.Timestamp], energy_ratings: dict, mean_inflows: dict):
+        """
+
+        Parameters
+        ----------
+        datetime_index: Time steps for which an OPF will be run
+        energy_ratings: Energy rating of each storage of the zone. Stored energy is initialised at half of it.
+        mean_inflows: Constant natural charging
+
+        Returns
+        -------
+
+        """
+        for storage in self._storages:
+            storage.build_energy_constraints(datetime_index=datetime_index,
+                                             energy_rating=energy_ratings[storage.name],
+                                             mean_inflow=mean_inflows[storage.name])
 
     def add_interconnection(self, interconnection: Interconnection):
         """
@@ -238,6 +253,18 @@ class Zone:
         """
         self._current_export = sum([line.get_export(zone=self) for line in self._interconnections])
 
+    def feasible_export_range(self, timestep: pd.Timestamp):
+        """
+        Returns the minimum and maximum net export compatible with the sectors availabilities (and storage constraints)
+        """
+        # Net constrained production due to the storages. Can be negative (constrained consumption).
+        net_constrained_production = sum([storage.constrained_production for storage in self._storages])
+        min_net_export = net_constrained_production - sum(sector.available_power(timestep)
+                                                          for sector in self._sectors if sector.is_load)
+        max_net_export = net_constrained_production + sum(sector.available_power(timestep)
+                                                          for sector in self._sectors if not sector.is_load)
+        return min_net_export, max_net_export
+
     def get_cost_function(self, timestep: pd.Timestamp) -> NodeCostFunction:
         """
         Returns the :class:`.NodeCostFunction` of the node.
@@ -252,9 +279,6 @@ class Zone:
             threshold_prices_list.extend(list(sector.price_model))
         threshold_prices_list = sorted(set(threshold_prices_list))
 
-        # Net constrained production due to the storages. Can be negative (constrained consumption)
-        net_constrained_production = sum([storage.constrained_production for storage in self._storages])
-
         # To compute the node cost function, we build in the first place its price/power curve by considering the
         # price_start and price_full of the loads and generators in the node. This is a piecewise linear function whose
         # "rupture" points are the threshold prices.
@@ -267,8 +291,7 @@ class Zone:
         # To satisfy all loads without producing anything in the node (leading to a cost of 0 in the node), the
         # following power is the opposite of what must be imported from the neighbour nodes.
         # This is the first point of the power/cost curve.
-        min_net_export = net_constrained_production - sum(sector.available_power(timestep)
-                                                          for sector in self._sectors if sector.is_load)
+        min_net_export, _ = self.feasible_export_range(timestep=timestep)
         last_power = min_net_export
         last_cost = 0  # Cost = 0 if full consumption and no production
         last_price = None

--- a/src/zone.py
+++ b/src/zone.py
@@ -167,16 +167,14 @@ class Zone:
 
     def build_storage_constraints(self, datetime_index: list[pd.Timestamp], energy_ratings: dict, mean_inflows: dict):
         """
+        Compute time series of min/max energy requirements per storage, to ensure no stored energy change between start
+        and end of the simulation (initial energy = final energy).
 
         Parameters
         ----------
         datetime_index: Time steps for which an OPF will be run
         energy_ratings: Energy rating of each storage of the zone. Stored energy is initialised at half of it.
         mean_inflows: Constant natural charging
-
-        Returns
-        -------
-
         """
         for storage in self._storages:
             storage.build_energy_constraints(datetime_index=datetime_index,

--- a/src/zone.py
+++ b/src/zone.py
@@ -149,7 +149,8 @@ class Zone:
             negative_demand = self._power_demand[self._power_demand < 0]
             return negative_demand.index
 
-    def add_storage(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool):
+    def add_storage(self, sector_name: str, historical_powers: pd.Series, is_controllable: bool, opf_mode: bool,
+                    energy_rating: float, mean_inflow: float):
         """
         Adds an energy storage unit to the zone. Updates the list of sectors accordingly.
         This includes both the charging (load) and discharging (generator) components that have the same sector name
@@ -157,11 +158,13 @@ class Zone:
         :param sector_name: Name of the storage unit
         :param historical_powers: Power time series of the storage (consumption and generation) in MW
         :param is_controllable: Indicates whether the storage behavior is controllable
+        :param energy_rating: Energy rating (in MW) of the storage. Used to run OPF but not to build price models.
+        :param mean_inflow: constant natural charging of the storage
         """
-        storage = Storage(sector_name, historical_powers, is_controllable, opf_mode=opf_mode)
-        storage.load.build_availabilities()
-        storage.generator.build_availabilities()
+        storage = Storage(sector_name, historical_powers, is_controllable, opf_mode=opf_mode,
+                          energy_rating=energy_rating, mean_inflow=mean_inflow)
         self._storages.append(storage)
+        # Availabilities are not built for storage
         self.sectors.append(storage.load)
         self.sectors.append(storage.generator)
 
@@ -185,8 +188,22 @@ class Zone:
 
         :param timestep: pd.Timestamp representing the current simulation timestep.
         """
+        generator_to_storage = dict()
+        load_to_storage = dict()
+        for storage in self._storages:
+            generator_to_storage[storage.generator] = storage
+            load_to_storage[storage.load] = storage
         for sector in self._sectors:
-            sector.store_simulated_power(timestep)
+            extra_power = 0  # Storage constrained production is not included in generator/load current power
+            if sector in generator_to_storage.keys():
+                constrained_production = generator_to_storage[sector].constrained_production
+                if constrained_production > 0:
+                    extra_power = constrained_production
+            elif sector in load_to_storage.keys():
+                constrained_production = load_to_storage[sector].constrained_production
+                if constrained_production < 0:
+                    extra_power = constrained_production  #
+            sector.store_simulated_power(timestep, extra_power=extra_power)
 
         assert self._current_cost_function is not None
         self._simulated_prices[timestep] = self._current_cost_function.compute_price(self._current_export)
@@ -235,6 +252,9 @@ class Zone:
             threshold_prices_list.extend(list(sector.price_model))
         threshold_prices_list = sorted(set(threshold_prices_list))
 
+        # Net constrained production due to the storages. Can be negative (constrained consumption)
+        net_constrained_production = sum([storage.constrained_production for storage in self._storages])
+
         # To compute the node cost function, we build in the first place its price/power curve by considering the
         # price_start and price_full of the loads and generators in the node. This is a piecewise linear function whose
         # "rupture" points are the threshold prices.
@@ -247,7 +267,8 @@ class Zone:
         # To satisfy all loads without producing anything in the node (leading to a cost of 0 in the node), the
         # following power is the opposite of what must be imported from the neighbour nodes.
         # This is the first point of the power/cost curve.
-        min_net_export = - sum(sector.available_powers[timestep] for sector in self._sectors if sector.is_load)
+        min_net_export = net_constrained_production - sum(sector.available_power(timestep)
+                                                          for sector in self._sectors if sector.is_load)
         last_power = min_net_export
         last_cost = 0  # Cost = 0 if full consumption and no production
         last_price = None
@@ -270,13 +291,13 @@ class Zone:
                     price_start, price_full = sector.price_model
                 if price_start == price == price_full:
                     # power_min += 0 because possible to have no production at this price
-                    power_max += sector.available_powers[timestep]
+                    power_max += sector.available_power(timestep)
                 elif price_start < price:
                     if price >= price_full:
                         factor = 1
                     else:  # price_start < price < price_full
                         factor = (price - price_start) / (price_full - price_start)
-                    power = sector.available_powers[timestep] * factor
+                    power = sector.available_power(timestep) * factor
                     power_min += power
                     power_max += power
 
@@ -345,10 +366,10 @@ class Zone:
                     factor = 1
                 else:  # price_start < price < price_full
                     factor = (price - sector_price_start) / (sector_price_full - sector_price_start)
-                power = sector.available_powers[timestep] * factor
+                power = sector.available_power(timestep) * factor
                 min_power = max_power = power
             elif price == sector_price_start == sector_price_full:
-                max_power = sector.available_powers[timestep]
+                max_power = sector.available_power(timestep)
             assert sector_name not in power_range_per_sector.keys()
             power_range_per_sector[sector_name] = (min_power, max_power)
 
@@ -377,7 +398,7 @@ class Zone:
                 if not sector.is_load:
                     sector.set_current_power(offer_range[0])
                 else:  # load shedding = demand - consumption
-                    sector.set_current_power(sector.available_powers[timestep] - offer_range[0])
+                    sector.set_current_power(sector.available_power(timestep) - offer_range[0])
                 sectors_with_power.append(sector_name)
 
         # Share loads & generators between real ones & storage ones
@@ -407,7 +428,7 @@ class Zone:
                     margin = max_offer - target_power  # >= 0
                     offer = max(offer_range[0], offer_range[1] - margin)  # as close as possible to offer_range[0]
                     if sector.is_load:  # offer is shedding
-                        actual_power = sector.available_powers[timestep] - offer  # consumption
+                        actual_power = sector.available_power(timestep) - offer  # consumption
                     else:
                         actual_power = offer  # production
                     sector.set_current_power(power=actual_power)
@@ -423,3 +444,11 @@ class Zone:
         """
         self._current_export = 0
         self._current_cost_function = None
+
+    def update_storages_availability(self, time_step: pd.Timestamp):
+        for storage in self._storages:
+            storage.update_availabilities(time_step=time_step)
+
+    def update_storages_energy(self):
+        for storage in self._storages:
+            storage.update_energy()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -554,7 +554,7 @@ def test_run_opfs(controller_opf_setup):
     controller._network.run_opf.return_value = (True, {})
 
     # Execution of the method to be tested
-    with patch('pandas.DataFrame.to_excel', autospec=True):
+    with patch('pandas.DataFrame.to_excel'):
         controller.run_opfs()
 
     # Vérifications

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -124,13 +124,13 @@ def test_build_price_models(controller_setup):
     assert network.add_zone.call_count == 4
     network.add_zone.assert_has_calls([
         call(zone_name="IBR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={}),
+             sectors_historical_powers=ANY, historical_prices=ANY),
         call(zone_name="FR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={}),
+             sectors_historical_powers=ANY, historical_prices=ANY),
         call(zone_name="IBR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={}),
+             sectors_historical_powers=ANY, historical_prices=ANY),
         call(zone_name="FR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={})
+             sectors_historical_powers=ANY, historical_prices=ANY)
     ])
 
     # Verify series in calls
@@ -551,9 +551,11 @@ def test_run_opfs(controller_opf_setup):
         "01/02/2018 12:00:00",
         "01/03/2018 12:00:00"
     ]
+    controller._network.run_opf.return_value = (True, {})
 
     # Execution of the method to be tested
-    controller.run_opfs()
+    with patch('pandas.DataFrame.to_excel', autospec=True):
+        controller.run_opfs()
 
     # Vérifications
     controller.build_network_model.assert_has_calls([
@@ -595,6 +597,7 @@ def test_export_opfs(controller_opf_setup):
     zone_mock_ibr = controller_opf_setup["zone_mock_ibr"]
     sector_mock = MagicMock()
     sector_mock.name = "sector_ibr"
+    sector_mock.is_load = False
     sector_mock.simulated_powers = pd.Series([10, 20, 30, 40, 50, 60], index=datetime_index)
     zone_mock_ibr.sectors = [sector_mock]
     controller._network.zones = {"IBR": zone_mock_ibr}

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -124,13 +124,13 @@ def test_build_price_models(controller_setup):
     assert network.add_zone.call_count == 4
     network.add_zone.assert_has_calls([
         call(zone_name="IBR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY),
+             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={}),
         call(zone_name="FR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY),
+             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={}),
         call(zone_name="IBR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY),
+             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={}),
         call(zone_name="FR", storages=["hydro pump storage"], controllable_sectors=['hydro pump storage'],
-             sectors_historical_powers=ANY, historical_prices=ANY)
+             sectors_historical_powers=ANY, historical_prices=ANY, energy_ratings={}, mean_inflows={})
     ])
 
     # Verify series in calls

--- a/tests/test_input_reader.py
+++ b/tests/test_input_reader.py
@@ -922,3 +922,44 @@ def test_keep_first_value_interco_powers_if_duplicated_timestep(setup):
         }).sort_values("Time")
 
     pd.testing.assert_frame_equal(historical_powers, expected_df)
+
+
+def test_read_db_storages_energy_data(setup):
+    # -- Create mocks -- #
+    fake_energy_df = pd.DataFrame(columns=["Country", "hydro_pumped_storage", "hydro_water_reservoir", "battery"],
+                                  data=[
+                                      ["FR", 50, 500, 5],
+                                      ["BE", 10, 100, 1],
+                                      ["NL", 20, 200, 2],
+                                  ])
+    fake_inflow_df = pd.DataFrame(columns=["Country", "hydro_pumped_storage", "hydro_water_reservoir", "battery"],
+                                  data=[
+                                       ["FR", 5, 50, 0],
+                                       ["BE", 1, 10, 0],
+                                       ["NL", 2, 20, 0],
+                                  ])
+    read_excel_mock = patch("pandas.read_excel", side_effect=[fake_energy_df, fake_inflow_df]).start()
+
+    # Mock the zones directly
+    db_dir = setup["data"]["fake directories"]["fake db dir"]
+    work_dir = setup["data"]["fake directories"]["fake work dir"]
+    input_reader = InputReader(db_dir=db_dir, work_dir=work_dir)
+    input_reader._zones = {"FRA": ["FR"], "BNX": ["BE", "NL"]}
+    input_reader._sectors_group = {"hydro": ["hydro_pumped_storage", "hydro_water_reservoir"], "battery": ["battery"]}
+    input_reader._storages = {"hydro", "battery"}
+
+    # Run the function
+    storage_data = input_reader.read_db_storages_energy_data()
+
+    # -- Expected result: aggregated by zone and main sector-- #
+    expected_energy_data = {"FRA": {"hydro": 550, "battery": 5}, "BNX": {"hydro": 330, "battery": 3}}
+    expected_inflow_data = {"FRA": {"hydro": 55, "battery": 0}, "BNX": {"hydro": 33, "battery": 0}}
+
+    assert storage_data == {"Energy MWh": expected_energy_data, "Mean inflow MW": expected_inflow_data}
+
+    # Check 'read_excel' calls
+    assert read_excel_mock.call_count == 2  # One for 'Energy MWh' and once for 'Mean inflow MW'
+    read_excel_mock.assert_has_calls([  # Check the parameter in each call
+        call(db_dir / "storages_energy_data.xlsx", sheet_name="Energy MWh"),
+        call(db_dir / "storages_energy_data.xlsx", sheet_name="Mean inflow MW"),
+    ], any_order=True)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,12 +1,12 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pandas as pd
 import pytest
 from pandas import Timestamp
 
+from src.interconnection import Interconnection
 from src.network import Network
 from src.zone import Zone
-from src.interconnection import Interconnection
 
 
 @pytest.fixture(scope="function")
@@ -178,34 +178,36 @@ def test_run_opf_makes_expected_calls():
     zone_1 = MagicMock(spec=Zone)
     zone_2 = MagicMock(spec=Zone)
     zone_3 = MagicMock(spec=Zone)
-    for zone in (zone_1, zone_2, zone_3):
-        zone.feasible_export_range.return_value = (-10, 10)
 
     interconnection_1 = MagicMock(spec=Interconnection)
     interconnection_1.optimise_export.side_effect = [-1, -.1, 0]
     interconnection_1.zone_from = zone_1
     interconnection_1.zone_to = zone_2
-    interconnection_1.historical_power.return_value = 1
 
     interconnection_2 = MagicMock(spec=Interconnection)
     interconnection_2.optimise_export.side_effect = [0, 0, 0]
     interconnection_2.zone_from = zone_2
     interconnection_2.zone_to = zone_3
-    interconnection_2.historical_power.return_value = 2
 
     network = Network(opf_mode=True)
     network._zones = {"1": zone_1, "2": zone_2, "3": zone_3}
     network._interconnections = [interconnection_1, interconnection_2]
+    fake_timestep = pd.Timestamp("2019-01-01 00:00:00")
 
-    converged = network.run_opf(timestep="fake_timestep")[0]
+    with patch.object(network, "initialise_opf") as initialise_opf_mock:
+        converged = network.run_opf(timestep=fake_timestep)
     assert converged
 
+    initialise_opf_mock.assert_called_once_with(timestep=fake_timestep)
     for zone in (zone_1, zone_2, zone_3):
         assert zone.market_optimisation.call_count == 2
-        assert zone.reset_powers.call_count == 1
-        assert zone.store_simulated_power.call_count == 1
-        assert zone.update_storages_availability.call_count == 1
+        zone.market_optimisation.assert_has_calls([call(fake_timestep), call(fake_timestep)])
+        zone.update_storages_energy.assert_called_once()
+        zone.store_simulated_power.assert_called_once_with(fake_timestep)
 
     for interconnection in (interconnection_1, interconnection_2):
         assert interconnection.optimise_export.call_count == 3  # Three iterations of the loop
-        assert interconnection.store_simulated_power.call_count == 1
+        interconnection.optimise_export.assert_has_calls([
+            call(fake_timestep), call(fake_timestep), call(fake_timestep)
+        ])
+        interconnection.store_simulated_power.assert_called_once_with(fake_timestep)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from pandas import Timestamp
 
-from src.interconnection import Interconnection
+from src.interconnection import ExteriorInterconnection, Interconnection, OUT_ZONE_NAME
 from src.network import Network
 from src.zone import Zone
 
@@ -211,3 +211,81 @@ def test_run_opf_makes_expected_calls():
             call(fake_timestep), call(fake_timestep), call(fake_timestep)
         ])
         interconnection.store_simulated_power.assert_called_once_with(fake_timestep)
+
+
+def test_initialise_opf_raise_warning_if_non_feasible_initialisation_requires_to_fake_the_exterior_interconnection():
+    timestep = pd.Timestamp("2019-01-01 00:00:00")
+
+    # Create network
+    ch_zone = Zone("CH", pd.Series())
+    fr_zone = Zone("FR", pd.Series())
+    out_zone = Zone(OUT_ZONE_NAME, pd.Series())
+
+    ch_fr_interconnection = Interconnection(fr_zone, ch_zone, power_rating=100,
+                                            historical_power_flows=pd.Series(10, index=[timestep]))
+    ch_outside_interconnection = ExteriorInterconnection(ch_zone, out_zone,
+                                                         historical_power_flows=pd.Series(20, index=[timestep]))
+    fr_outside_interconnection = ExteriorInterconnection(fr_zone, out_zone,
+                                                         historical_power_flows=pd.Series(0, index=[timestep]))
+
+    ch_zone._interconnections = [ch_fr_interconnection, ch_outside_interconnection]
+    fr_zone._interconnections = [ch_fr_interconnection, fr_outside_interconnection]
+
+    network = Network(opf_mode=True)
+    network._zones = {'CH': ch_zone, 'FR': fr_zone}
+    network._interconnections = [ch_fr_interconnection, ch_outside_interconnection, fr_outside_interconnection]
+
+    # Fake feasible export per zone
+    ch_feasible_export = (-15, 0)
+    fr_feasible_export = (-10, 10)
+
+    with patch.object(Zone, "reset_powers"), patch.object(Zone, "update_storages_availability"), \
+            patch.object(Zone, "feasible_export_range", side_effect=[ch_feasible_export, fr_feasible_export]), \
+            patch("warnings.warn") as warning_mock:
+        network.initialise_opf(timestep)
+
+    # Check warning message
+    warning_mock.assert_called_with(
+        f"At timestep {timestep}, zone CH export constraints could not be satisfied. "
+        f"Interconnection with the outside zone is modified by -10, therefore "
+        "simulation results cannot be compared with historical data", stacklevel=2
+    )
+
+
+def test_initialise_opf_raise_warning_if_non_feasible_initialisation_requires_to_fake_the_exterior_interconnection_2():
+    timestep = pd.Timestamp("2019-01-01 00:00:00")
+
+    # Create network
+    ch_zone = Zone("CH", pd.Series())
+    fr_zone = Zone("FR", pd.Series())
+    out_zone = Zone(OUT_ZONE_NAME, pd.Series())
+
+    ch_fr_interconnection = Interconnection(fr_zone, ch_zone, power_rating=100,
+                                            historical_power_flows=pd.Series(10, index=[timestep]))
+    ch_outside_interconnection = ExteriorInterconnection(ch_zone, out_zone,
+                                                         historical_power_flows=pd.Series(20, index=[timestep]))
+    fr_outside_interconnection = ExteriorInterconnection(fr_zone, out_zone,
+                                                         historical_power_flows=pd.Series(0, index=[timestep]))
+
+    ch_zone._interconnections = [ch_fr_interconnection, ch_outside_interconnection]
+    fr_zone._interconnections = [ch_fr_interconnection, fr_outside_interconnection]
+
+    network = Network(opf_mode=True)
+    network._zones = {'CH': ch_zone, 'FR': fr_zone}
+    network._interconnections = [ch_fr_interconnection, ch_outside_interconnection, fr_outside_interconnection]
+
+    # Fake feasible export per zone
+    ch_feasible_export = (-10, 10)
+    fr_feasible_export = (-10, 5)
+
+    with patch.object(Zone, "reset_powers"), patch.object(Zone, "update_storages_availability"), \
+            patch.object(Zone, "feasible_export_range", side_effect=[ch_feasible_export, fr_feasible_export]), \
+            patch("warnings.warn") as warning_mock:
+        network.initialise_opf(timestep)
+
+    # Check warning message
+    warning_mock.assert_called_with(
+        f"At timestep {timestep}, zone CH export constraints could not be satisfied. "
+        f"Interconnection with the outside zone is modified by -5, therefore "
+        "simulation results cannot be compared with historical data", stacklevel=2
+    )

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -5,6 +5,8 @@ import pytest
 from pandas import Timestamp
 
 from src.network import Network
+from src.zone import Zone
+from src.interconnection import Interconnection
 
 
 @pytest.fixture(scope="function")
@@ -64,7 +66,8 @@ def test_add_zone(network_setup):
                      sectors_historical_powers=setup["sectors_historical_powers"],
                      storages=setup["storages"],
                      controllable_sectors=setup["controllable_sectors"],
-                     historical_prices=setup["historical_prices"])
+                     historical_prices=setup["historical_prices"],
+                     energy_ratings={}, mean_inflows={})
 
     # Check that Zone has been created with the correct parameters
     setup["zone_cls"].assert_called_once_with("FR", setup["historical_prices"])
@@ -75,7 +78,8 @@ def test_add_zone(network_setup):
     setup["zone"].add_storage.assert_called_once_with("hydro pump storage",
                                                       setup["sectors_historical_powers"]["hydro pump storage"],
                                                       True,
-                                                      opf_mode=False)
+                                                      opf_mode=False,
+                                                      energy_rating=0, mean_inflow=0)
 
     # Check that zone has been added to networks.zone
     assert setup["zone"] in network._zones.values()
@@ -110,7 +114,8 @@ def test_add_zone_updates_datetime_index(network_setup):
     network.add_zone(zone_name="FR", sectors_historical_powers=sectors_historical_powers,
                      storages=setup["storages"],
                      controllable_sectors=setup["controllable_sectors"],
-                     historical_prices=historical_prices)
+                     historical_prices=historical_prices,
+                     energy_ratings={}, mean_inflows={})
 
     # Check that Zone has been created with the correct parameters
     setup["zone_cls"].assert_called_once_with("FR", historical_prices)
@@ -121,7 +126,8 @@ def test_add_zone_updates_datetime_index(network_setup):
     setup["zone"].add_storage.assert_called_once_with("hydro pump storage",
                                                       sectors_historical_powers["hydro pump storage"],
                                                       True,
-                                                      opf_mode=True)
+                                                      opf_mode=True,
+                                                      energy_rating=0, mean_inflow=0)
 
     # Check that zone has been added to networks.zone
     assert setup["zone"] in network._zones.values()
@@ -172,5 +178,29 @@ def test_set_price_model(network_setup):
     network_setup["zone"].set_price_model.assert_called_once_with(price_models["FR"])
 
 
-def test_run_opf():
-    pass
+def test_run_opf_makes_expected_calls():
+    zone_1 = MagicMock(spec=Zone)
+    zone_2 = MagicMock(spec=Zone)
+    zone_3 = MagicMock(spec=Zone)
+
+    interconnection_1 = MagicMock(spec=Interconnection)
+    interconnection_1.optimise_export.side_effect = [-1, -.1, 0]
+    interconnection_2 = MagicMock(spec=Interconnection)
+    interconnection_2.optimise_export.side_effect = [0, 0, 0]
+
+    network = Network(opf_mode=True)
+    network._zones = {"1": zone_1, "2": zone_2, "3": zone_3}
+    network._interconnections = [interconnection_1, interconnection_2]
+
+    converged = network.run_opf(timestep="fake_time_step")
+    assert converged
+
+    for zone in (zone_1, zone_2, zone_3):
+        assert zone.market_optimisation.call_count == 2
+        assert zone.reset_powers.call_count == 1
+        assert zone.store_simulated_power.call_count == 1
+        assert zone.update_storages_availability.call_count == 1
+
+    for interconnection in (interconnection_1, interconnection_2):
+        assert interconnection.optimise_export.call_count == 3  # Three iterations of the loop
+        assert interconnection.store_simulated_power.call_count == 1

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -66,8 +66,7 @@ def test_add_zone(network_setup):
                      sectors_historical_powers=setup["sectors_historical_powers"],
                      storages=setup["storages"],
                      controllable_sectors=setup["controllable_sectors"],
-                     historical_prices=setup["historical_prices"],
-                     energy_ratings={}, mean_inflows={})
+                     historical_prices=setup["historical_prices"])
 
     # Check that Zone has been created with the correct parameters
     setup["zone_cls"].assert_called_once_with("FR", setup["historical_prices"])
@@ -78,8 +77,7 @@ def test_add_zone(network_setup):
     setup["zone"].add_storage.assert_called_once_with("hydro pump storage",
                                                       setup["sectors_historical_powers"]["hydro pump storage"],
                                                       True,
-                                                      opf_mode=False,
-                                                      energy_rating=0, mean_inflow=0)
+                                                      opf_mode=False)
 
     # Check that zone has been added to networks.zone
     assert setup["zone"] in network._zones.values()
@@ -114,8 +112,7 @@ def test_add_zone_updates_datetime_index(network_setup):
     network.add_zone(zone_name="FR", sectors_historical_powers=sectors_historical_powers,
                      storages=setup["storages"],
                      controllable_sectors=setup["controllable_sectors"],
-                     historical_prices=historical_prices,
-                     energy_ratings={}, mean_inflows={})
+                     historical_prices=historical_prices)
 
     # Check that Zone has been created with the correct parameters
     setup["zone_cls"].assert_called_once_with("FR", historical_prices)
@@ -126,8 +123,7 @@ def test_add_zone_updates_datetime_index(network_setup):
     setup["zone"].add_storage.assert_called_once_with("hydro pump storage",
                                                       sectors_historical_powers["hydro pump storage"],
                                                       True,
-                                                      opf_mode=True,
-                                                      energy_rating=0, mean_inflow=0)
+                                                      opf_mode=True)
 
     # Check that zone has been added to networks.zone
     assert setup["zone"] in network._zones.values()
@@ -182,17 +178,26 @@ def test_run_opf_makes_expected_calls():
     zone_1 = MagicMock(spec=Zone)
     zone_2 = MagicMock(spec=Zone)
     zone_3 = MagicMock(spec=Zone)
+    for zone in (zone_1, zone_2, zone_3):
+        zone.feasible_export_range.return_value = (-10, 10)
 
     interconnection_1 = MagicMock(spec=Interconnection)
     interconnection_1.optimise_export.side_effect = [-1, -.1, 0]
+    interconnection_1.zone_from = zone_1
+    interconnection_1.zone_to = zone_2
+    interconnection_1.historical_power.return_value = 1
+
     interconnection_2 = MagicMock(spec=Interconnection)
     interconnection_2.optimise_export.side_effect = [0, 0, 0]
+    interconnection_2.zone_from = zone_2
+    interconnection_2.zone_to = zone_3
+    interconnection_2.historical_power.return_value = 2
 
     network = Network(opf_mode=True)
     network._zones = {"1": zone_1, "2": zone_2, "3": zone_3}
     network._interconnections = [interconnection_1, interconnection_2]
 
-    converged = network.run_opf(timestep="fake_timestep")
+    converged = network.run_opf(timestep="fake_timestep")[0]
     assert converged
 
     for zone in (zone_1, zone_2, zone_3):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -192,7 +192,7 @@ def test_run_opf_makes_expected_calls():
     network._zones = {"1": zone_1, "2": zone_2, "3": zone_3}
     network._interconnections = [interconnection_1, interconnection_2]
 
-    converged = network.run_opf(timestep="fake_time_step")
+    converged = network.run_opf(timestep="fake_timestep")
     assert converged
 
     for zone in (zone_1, zone_2, zone_3):

--- a/tests/test_sector.py
+++ b/tests/test_sector.py
@@ -114,6 +114,34 @@ def test_build_availabilities_parametrized(name, is_storage_load, is_controllabl
     assert len(result) == len(powers)
 
 
+@pytest.mark.parametrize("name, is_controllable, is_storage, is_load", [
+    ("PV", False, False, False),
+    ("Fossil", True, False, False),
+    ("Hydro gen", True, True, False),
+    ("Hydro load", True, True, True),
+    ("Industry", False, False, True),
+])
+def test_available_power(name, is_storage, is_load, is_controllable):
+    historical_powers = pd.Series([100, 200, 150], index=date_range("2015-01-01", periods=3, freq="H"))
+    sector = Sector(sector_name=name, historical_powers=historical_powers,
+                    is_controllable=is_controllable, is_load=is_load)
+    if is_storage:
+        for i in range(len(historical_powers)):
+            time_step = historical_powers.index[i]
+            for available_power in (10, 20):
+                sector._available_power = available_power
+                assert sector.available_power(timestep=time_step) == available_power
+    else:
+        sector.build_availabilities()
+        for i in range(len(historical_powers)):
+            time_step = historical_powers.index[i]
+            if is_controllable:
+                available_power = 200
+            else:
+                available_power = historical_powers[i]
+            assert sector.available_power(timestep=time_step) == available_power
+
+
 # ------- Tests build_price_model -------
 
 @pytest.mark.parametrize("sector_key, ascending", [
@@ -260,14 +288,15 @@ def test_store_simulated_power(sector_setup):
     sector = sector_setup["sector_prod"]
     timestep = pd.Timestamp("2015-01-01 12:00:00")
 
-    sector._current_power = 150
+    for extra_power in (0, 10, -10):
+        sector._current_power = 150
 
-    # tested method
-    sector.store_simulated_power(timestep)
+        # tested method
+        sector.store_simulated_power(timestep, extra_power=extra_power)
 
-    # Verifications
-    expected_series = pd.Series([150], index=[timestep])
+        # Verifications
+        expected_series = pd.Series([150 + extra_power], index=[timestep])
 
-    pd.testing.assert_series_equal(sector._simulated_powers, expected_series)
+        pd.testing.assert_series_equal(sector._simulated_powers, expected_series)
 
-    assert sector._current_power == 0
+        assert sector._current_power == 0

--- a/tests/test_sector.py
+++ b/tests/test_sector.py
@@ -126,20 +126,18 @@ def test_available_power(name, is_storage, is_load, is_controllable):
     sector = Sector(sector_name=name, historical_powers=historical_powers,
                     is_controllable=is_controllable, is_load=is_load)
     if is_storage:
-        for i in range(len(historical_powers)):
-            time_step = historical_powers.index[i]
+        for timestep in historical_powers.index:
             for available_power in (10, 20):
                 sector._available_power = available_power
-                assert sector.available_power(timestep=time_step) == available_power
+                assert sector.available_power(timestep=timestep) == available_power
     else:
         sector.build_availabilities()
-        for i in range(len(historical_powers)):
-            time_step = historical_powers.index[i]
+        for timestep, power in historical_powers.items():
             if is_controllable:
                 available_power = 200
             else:
-                available_power = historical_powers[i]
-            assert sector.available_power(timestep=time_step) == available_power
+                available_power = power
+            assert sector.available_power(timestep=timestep) == available_power
 
 
 # ------- Tests build_price_model -------

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -17,12 +17,31 @@ def storage_setup():
     powers = pd.Series([-100, 0, 150], index=timestamps)
 
     # Sector patch
-    sector = patch("src.storage.Sector")
-    sector_cls = sector.start()
+    # sector = patch("src.storage.Sector")
+    # sector_cls = sector.start()
 
     # Load et generator sectors mocks
     sector_load = MagicMock(name="sector_load")
     sector_generator = MagicMock(name="sector_generator")
+
+    # Configuring mock behaviour: 1st call for load, 2nd for generator
+    # sector_cls.side_effect = [sector_load, sector_generator]
+    sector_cls = patch("src.storage.Sector", side_effect=[sector_load, sector_generator]).start()
+    yield {
+        "powers": powers,
+        "sector_cls": sector_cls,
+        "sector_load": sector_load,
+        "sector_generator": sector_generator,
+    }
+
+    patch.stopall()
+
+
+@pytest.fixture(scope='function')
+def storage_setup2(storage_setup):
+    powers = storage_setup["powers"]
+    sector_load = storage_setup["sector_load"]
+    sector_generator = storage_setup["sector_generator"]
 
     sector_load.power_rating = 4
     sector_generator.power_rating = 4
@@ -36,17 +55,11 @@ def storage_setup():
     sector_generator.set_available_power.side_effect = gen_side_effect
     sector_load.set_available_power.side_effect = load_side_effect
 
-    # Configuring mock behaviour: 1st call for load, 2nd for generator
-    sector_cls.side_effect = [sector_load, sector_generator]
-
     storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True,
                       energy_rating=10, mean_inflow=1)
 
     yield {
         "powers": powers,
-        "sector_cls": sector_cls,
-        "sector_load": sector_load,
-        "sector_generator": sector_generator,
         "storage": storage
     }
 
@@ -110,9 +123,9 @@ def test_build_energy_constraints():
     ]
 
 
-def test_update_availabilities(storage_setup):
-    powers = storage_setup["powers"]
-    storage = storage_setup["storage"]
+def test_update_availabilities(storage_setup2):
+    powers = storage_setup2["powers"]
+    storage = storage_setup2["storage"]
 
     assert storage._energy_constraints == [
         (0, 7),
@@ -134,7 +147,7 @@ def test_update_availabilities(storage_setup):
     ]:
         storage._stored_energy = stored_energy
         storage._current_hour = hour
-        storage.update_availabilities(time_step=powers.index[hour])
+        storage.update_availabilities(timestep=powers.index[hour])
 
         assert storage.constrained_production == constrained_power
         assert storage.generator.available_power == available_gen
@@ -150,8 +163,8 @@ def test_update_availabilities(storage_setup):
     (-1, 0, 0, 7),
     (-0.5, 0, 0.5, 7),
 ])
-def test_compute_new_energy(storage_setup, constrained_power, gen_power, load_power, next_energy):
-    storage = storage_setup["storage"]
+def test_compute_new_energy(storage_setup2, constrained_power, gen_power, load_power, next_energy):
+    storage = storage_setup2["storage"]
 
     storage.load.current_power = load_power
     storage.generator.current_power = gen_power
@@ -165,8 +178,8 @@ def test_compute_new_energy(storage_setup, constrained_power, gen_power, load_po
     assert storage._next_energy == expected_next_energy
 
 
-def test_update_energy_updates_expected_attributes(storage_setup):
-    storage = storage_setup["storage"]
+def test_update_energy_updates_expected_attributes(storage_setup2):
+    storage = storage_setup2["storage"]
 
     # Run function
     storage._next_energy = 10

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -24,28 +24,45 @@ def storage_setup():
     sector_load = MagicMock(name="sector_load")
     sector_generator = MagicMock(name="sector_generator")
 
+    sector_load.power_rating = 4
+    sector_generator.power_rating = 4
+
+    def gen_side_effect(power):
+        sector_generator.available_power = power
+
+    def load_side_effect(power):
+        sector_load.available_power = power
+
+    sector_generator.set_available_power.side_effect = gen_side_effect
+    sector_load.set_available_power.side_effect = load_side_effect
+
     # Configuring mock behaviour: 1st call for load, 2nd for generator
     sector_cls.side_effect = [sector_load, sector_generator]
+
+    storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True,
+                      energy_rating=10, mean_inflow=1)
 
     yield {
         "powers": powers,
         "sector_cls": sector_cls,
         "sector_load": sector_load,
         "sector_generator": sector_generator,
+        "storage": storage
     }
 
     patch.stopall()
 
 
 # TODO add test with opf_mode=True and check indexes
-def test_storage_initializes_load_and_generator(storage_setup):
+def test_storage_initializes_load_and_generator(storage_setup):  # FIXME test do not pass
     powers = storage_setup["powers"]
     sector_cls = storage_setup["sector_cls"]
     sector_load = storage_setup["sector_load"]
     sector_generator = storage_setup["sector_generator"]
 
     # Creation of the object storage
-    storage = Storage("hydro pump storage", powers, is_controllable=True, opf_mode=False)
+    storage = Storage("hydro pump storage", powers, is_controllable=True, opf_mode=False,
+                      energy_rating=0, mean_inflow=0)
 
     # Check that Sector class has been called properly
     assert sector_cls.call_count == 2
@@ -73,3 +90,90 @@ def test_storage_initializes_load_and_generator(storage_setup):
     # Check the attributes
     assert storage.load is sector_load
     assert storage.generator is sector_generator
+
+
+def test_build_energy_constraints():
+    # Time series with positive and negative powers
+    timestamps = [Timestamp(f"01/01/2015 {i}:00:00") for i in range(6)]
+    powers = pd.Series([-30, 40, 0, 0, 0, 0], index=timestamps)
+
+    # Creation of the object storage
+    storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True,
+                      energy_rating=100, mean_inflow=1)
+    assert storage._energy_constraints == [
+        (0, 100),
+        (0, 100),
+        (2, 100),
+        (18, 88),
+        (34, 69),  # inflow + 1/2 consumption rating = +16 | inflow - 1/2 production rating = -19
+        (50, 50),
+    ]
+
+
+def test_update_availabilities(storage_setup):
+    powers = storage_setup["powers"]
+    storage = storage_setup["storage"]
+
+    assert storage._energy_constraints == [
+        (0, 7),
+        (2, 6),  # inflow + 1/2 consumption rating = +3 | inflow - 1/2 production rating = -1
+        (5, 5),
+    ]
+    for (hour, stored_energy, constrained_power, available_gen, available_load) in [
+        (1, 0, -1, 0, 3),
+        (1, 1, 0, 0, 4),
+        (1, 2, 0, 1, 3),
+        (1, 4, 0, 3, 1),
+        (1, 6, 1, 3, 0),
+        (1, 7, 2, 2, 0),
+        (2, 2, -2, 0, 0),
+        (2, 4, 0, 0, 0),
+        (2, 5, 1, 0, 0),
+        (2, 6, 2, 0, 0),
+
+    ]:
+        storage._stored_energy = stored_energy
+        storage._current_hour = hour
+        storage.update_availabilities(time_step=powers.index[hour])
+
+        assert storage.constrained_production == constrained_power
+        assert storage.generator.available_power == available_gen
+        assert storage.load.available_power == available_load
+
+
+@pytest.mark.parametrize("constrained_power, gen_power, load_power, next_energy", [
+    (0, 1, 0, 5),
+    (0, 0, 0, 6),
+    (0, 0, 1, 7),
+    (2, 1, 0, 3),
+    (2, 0, 0, 4),
+    (-1, 0, 0, 7),
+    (-0.5, 0, 0.5, 7),
+])
+def test_compute_new_energy(storage_setup, constrained_power, gen_power, load_power, next_energy):
+    storage = storage_setup["storage"]
+
+    storage.load.current_power = load_power
+    storage.generator.current_power = gen_power
+    storage._constrained_production = constrained_power
+
+    # Compute the new energy
+    storage._compute_new_energy()
+
+    # Check results
+    expected_next_energy = next_energy  # initial energy + inflow + consumption - production
+    assert storage._next_energy == expected_next_energy
+
+
+def test_update_energy_updates_expected_attributes(storage_setup):
+    storage = storage_setup["storage"]
+
+    # Run function
+    storage._next_energy = 10
+    storage._current_hour = 15
+    storage.update_energy()
+
+    # Check attributes
+    assert storage._stored_energy == 10
+    assert storage._next_energy is None
+    assert storage._current_hour == 16

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -16,17 +16,13 @@ def storage_setup():
     ]
     powers = pd.Series([-100, 0, 150], index=timestamps)
 
-    # Sector patch
-    # sector = patch("src.storage.Sector")
-    # sector_cls = sector.start()
-
     # Load et generator sectors mocks
     sector_load = MagicMock(name="sector_load")
     sector_generator = MagicMock(name="sector_generator")
 
     # Configuring mock behaviour: 1st call for load, 2nd for generator
-    # sector_cls.side_effect = [sector_load, sector_generator]
     sector_cls = patch("src.storage.Sector", side_effect=[sector_load, sector_generator]).start()
+
     yield {
         "powers": powers,
         "sector_cls": sector_cls,
@@ -55,8 +51,8 @@ def storage_setup2(storage_setup):
     sector_generator.set_available_power.side_effect = gen_side_effect
     sector_load.set_available_power.side_effect = load_side_effect
 
-    storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True,
-                      energy_rating=10, mean_inflow=1)
+    storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True)
+    storage.build_energy_constraints(datetime_index=list(powers.index), energy_rating=10, mean_inflow=1)
 
     yield {
         "powers": powers,
@@ -67,15 +63,14 @@ def storage_setup2(storage_setup):
 
 
 # TODO add test with opf_mode=True and check indexes
-def test_storage_initializes_load_and_generator(storage_setup):  # FIXME test do not pass
+def test_storage_initializes_load_and_generator(storage_setup):
     powers = storage_setup["powers"]
     sector_cls = storage_setup["sector_cls"]
     sector_load = storage_setup["sector_load"]
     sector_generator = storage_setup["sector_generator"]
 
     # Creation of the object storage
-    storage = Storage("hydro pump storage", powers, is_controllable=True, opf_mode=False,
-                      energy_rating=0, mean_inflow=0)
+    storage = Storage("hydro pump storage", powers, is_controllable=True, opf_mode=False)
 
     # Check that Sector class has been called properly
     assert sector_cls.call_count == 2
@@ -111,27 +106,45 @@ def test_build_energy_constraints():
     powers = pd.Series([-30, 40, 0, 0, 0, 0], index=timestamps)
 
     # Creation of the object storage
-    storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True,
-                      energy_rating=100, mean_inflow=1)
-    assert storage._energy_constraints == [
+    storage = Storage(sector_name="hydro pump storage", historical_powers=powers, is_controllable=True, opf_mode=True)
+    storage.build_energy_constraints(datetime_index=timestamps, energy_rating=100, mean_inflow=1)
+    assert (storage._energy_constraints.values == [
         (0, 100),
         (0, 100),
         (2, 100),
         (18, 88),
         (34, 69),  # inflow + 1/2 consumption rating = +16 | inflow - 1/2 production rating = -19
         (50, 50),
-    ]
+    ]).all()
+    storage.build_energy_constraints(datetime_index=timestamps, energy_rating=100, mean_inflow=30)
+    assert (storage._energy_constraints.values == [
+        (0, 50),
+        (0, 50),
+        (0, 50),
+        (0, 50),
+        (5, 50),  # inflow + 1/2 consumption rating = +45 | inflow - 1/2 production rating = +10 -> 0
+        (50, 50),
+    ]).all()
+    storage.build_energy_constraints(datetime_index=timestamps, energy_rating=100, mean_inflow=-30)
+    assert (storage._energy_constraints.values == [
+        (50, 100),
+        (50, 100),
+        (50, 100),
+        (50, 100),
+        (50, 100),  # inflow + 1/2 consumption rating = -15 -> 0 | inflow - 1/2 production rating = -50
+        (50, 50),
+    ]).all()
 
 
 def test_update_availabilities(storage_setup2):
     powers = storage_setup2["powers"]
     storage = storage_setup2["storage"]
 
-    assert storage._energy_constraints == [
+    assert (storage._energy_constraints.values == [
         (0, 7),
         (2, 6),  # inflow + 1/2 consumption rating = +3 | inflow - 1/2 production rating = -1
         (5, 5),
-    ]
+    ]).all()
     for (hour, stored_energy, constrained_power, available_gen, available_load) in [
         (1, 0, -1, 0, 3),
         (1, 1, 0, 0, 4),
@@ -146,7 +159,6 @@ def test_update_availabilities(storage_setup2):
 
     ]:
         storage._stored_energy = stored_energy
-        storage._current_hour = hour
         storage.update_availabilities(timestep=powers.index[hour])
 
         assert storage.constrained_production == constrained_power
@@ -169,6 +181,7 @@ def test_compute_new_energy(storage_setup2, constrained_power, gen_power, load_p
     storage.load.current_power = load_power
     storage.generator.current_power = gen_power
     storage._constrained_production = constrained_power
+    storage._timestep = Timestamp("01/01/2015 12:00:00")
 
     # Compute the new energy
     storage._compute_new_energy()
@@ -183,10 +196,8 @@ def test_update_energy_updates_expected_attributes(storage_setup2):
 
     # Run function
     storage._next_energy = 10
-    storage._current_hour = 15
     storage.update_energy()
 
     # Check attributes
     assert storage._stored_energy == 10
     assert storage._next_energy is None
-    assert storage._current_hour == 16

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -86,10 +86,12 @@ def test_add_storage(zone_test_setup):
     storage = zone_test_setup["storage"]
     is_controllable = False
 
-    zone.add_storage("hydro pump storage", powers, is_controllable=is_controllable, opf_mode=False)
+    zone.add_storage("hydro pump storage", powers, is_controllable=is_controllable, opf_mode=False,
+                     energy_rating=0, mean_inflow=0)
 
     # Checks that Storage has been instantiated with the correct arguments
-    storage_cls.assert_called_once_with("hydro pump storage", powers, is_controllable, opf_mode=False)
+    storage_cls.assert_called_once_with("hydro pump storage", powers, is_controllable, opf_mode=False,
+                                        energy_rating=0, mean_inflow=0)
 
     # Check that both load and generator sectors have been added to the sectors list
     # (and that the object storage to the storages list)
@@ -133,7 +135,8 @@ def test_save_plots_calls_plot_result_with_correct_path(zone_test_setup, tmp_pat
     # Add a storage --> add 2 sectors (load and generator)
     storage.load.is_load = True  # Storage mock
     storage.generator.is_load = False
-    zone.add_storage("hydro pump storage", zone_test_setup["powers"], is_controllable=is_controllable, opf_mode=False)
+    zone.add_storage("hydro pump storage", zone_test_setup["powers"], is_controllable=is_controllable,
+                     opf_mode=False, energy_rating=0, mean_inflow=0)
 
     # Method to test
     zone.save_plots(tmp_path)
@@ -247,7 +250,13 @@ def test_updated_simulated_powers(zone_test_setup):
     # Mock sectors
     solar = MagicMock()
     nuclear = MagicMock()
-    zone._sectors = [solar, nuclear]
+    battery_gen = MagicMock()
+    battery_load = MagicMock()
+    storage = MagicMock()
+    storage.generator = battery_gen
+    storage.load = battery_load
+    zone._sectors = [solar, nuclear, battery_gen, battery_load]
+    zone._storages = [storage]
 
     # Mock interconnections
     interconnection1 = MagicMock()
@@ -259,10 +268,40 @@ def test_updated_simulated_powers(zone_test_setup):
     timestep = pd.Timestamp("2015-01-01 12:00:00")
 
     # Act
+    storage.constrained_production = 2
     zone.store_simulated_power(timestep)
     zone._current_cost_function.compute_price.assert_called_once()
 
     # Assert
     # Check that each sector has called store_simulated_power with the correct timestep
     for sector in zone._sectors:
-        sector.store_simulated_power.assert_called_once_with(timestep)
+        if sector is battery_gen:
+            sector.store_simulated_power.assert_called_once_with(timestep, extra_power=2)
+        else:
+            sector.store_simulated_power.assert_called_once_with(timestep, extra_power=0)
+
+
+def test_update_storages_availability(zone_test_setup):
+    zone = zone_test_setup["zone"]
+
+    # Mock sectors
+    storage = MagicMock()
+    zone._storages = [storage]
+
+    # Fake timestep
+    timestep = pd.Timestamp("2015-01-01 12:00:00")
+
+    zone.update_storages_availability(timestep)
+    # Check that each sector has called store_simulated_power with the correct timestep
+    storage.update_availabilities.assert_called_once_with(time_step=timestep)
+
+
+def test_update_storages_energy(zone_test_setup):
+    zone = zone_test_setup["zone"]
+
+    # Mock sectors
+    storage = MagicMock()
+    zone._storages = [storage]
+
+    zone.update_storages_energy()
+    storage.update_energy.assert_called_once()

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -293,7 +293,7 @@ def test_update_storages_availability(zone_test_setup):
 
     zone.update_storages_availability(timestep)
     # Check that each sector has called store_simulated_power with the correct timestep
-    storage.update_availabilities.assert_called_once_with(time_step=timestep)
+    storage.update_availabilities.assert_called_once_with(timestep=timestep)
 
 
 def test_update_storages_energy(zone_test_setup):

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -86,12 +86,10 @@ def test_add_storage(zone_test_setup):
     storage = zone_test_setup["storage"]
     is_controllable = False
 
-    zone.add_storage("hydro pump storage", powers, is_controllable=is_controllable, opf_mode=False,
-                     energy_rating=0, mean_inflow=0)
+    zone.add_storage("hydro pump storage", powers, is_controllable=is_controllable, opf_mode=False)
 
     # Checks that Storage has been instantiated with the correct arguments
-    storage_cls.assert_called_once_with("hydro pump storage", powers, is_controllable, opf_mode=False,
-                                        energy_rating=0, mean_inflow=0)
+    storage_cls.assert_called_once_with("hydro pump storage", powers, is_controllable, opf_mode=False)
 
     # Check that both load and generator sectors have been added to the sectors list
     # (and that the object storage to the storages list)
@@ -136,7 +134,7 @@ def test_save_plots_calls_plot_result_with_correct_path(zone_test_setup, tmp_pat
     storage.load.is_load = True  # Storage mock
     storage.generator.is_load = False
     zone.add_storage("hydro pump storage", zone_test_setup["powers"], is_controllable=is_controllable,
-                     opf_mode=False, energy_rating=0, mean_inflow=0)
+                     opf_mode=False)
 
     # Method to test
     zone.save_plots(tmp_path)


### PR DESCRIPTION
Add energy constraints for storages.
New file needed in the database for energy ratings and mean inflow per country per storage.
1 test still not pass.